### PR TITLE
revive and finish resolver code

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,10 +1,14 @@
 S src
+S server
 S resolver
+S mirage
 S test
 
 B _build/**
 
-PKG astring alcotest cstruct rresult afl-persistent cstruct.ppx ipaddr
+PKG astring alcotest cstruct rresult afl-persistent cstruct.ppx ipaddr fmt
 PKG mtime mtime.clock.os
 PKG duration lru logs
 PKG ptime nocrypto randomconv
+
+PKG lwt mirage-stack-lwt mirage-types-lwt

--- a/.ocamlinit
+++ b/.ocamlinit
@@ -1,5 +1,9 @@
 #utop_prompt_dummy
 #use "topfind"
-#require "cstruct, astring, ipaddr, logs, rresult, fmt, logs.fmt, ptime, duration, randomconv"
+#require "cstruct, astring, ipaddr, logs, rresult, fmt, logs.fmt, ptime, duration, randomconv, lru"
 #directory "_build/src"
 #load "udns.cma"
+#directory "_build/server"
+#load "udns_server.cma"
+#directory "_build/resolver"
+#load "udns_resolver.cma"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# udns - an opinionated Domain Name System (DNS) library
+# µDNS - an opinionated Domain Name System (DNS) library
 
 [![Build Status](https://travis-ci.org/roburio/udns.svg?branch=master)](https://travis-ci.org/roburio/udns)
 
@@ -16,13 +16,11 @@ needs a fully-fledged authoritative nameserver as well (for overriding various
 zones such as `.localhost` and reverse lookups of RFC 1918 IP ranges).
 
 Legacy resource record types are not dealt with, and there is no plan to support
-`ISDN`, `MAILA`, `MAILB`, `WKS`, `MB`, `NULL`, `HINFO`, ... .  `ANY` and `AXFR`
-are only handled via a TCP connection.  The only resource class supported is
-`IN` (the Internet).  In a similar vein, wildcard records are _not_ supported,
-and it is unlikely they'll ever be in this library.  Truncated hmac in `TSIG`
-are not supported (always full length of the hash algorithm).  `EDNS` is not yet
-supported (but planned).  The resolver code is not yet ready (and disconnected
-from the build system).
+`ISDN`, `MAILA`, `MAILB`, `WKS`, `MB`, `NULL`, `HINFO`, ... .  `AXFR` is only
+handled via TCP connections.  The only resource class supported is `IN` (the
+Internet).  In a similar vein, wildcard records are _not_ supported, and it is
+unlikely they'll ever be in this library.  Truncated hmac in `TSIG` are not
+supported (always the full length of the hash algorithm is used).
 
 Please read [the blog article](https://hannes.nqsb.io/Posts/DNS) for a more
 detailed overview.
@@ -38,28 +36,62 @@ detailed overview.
 * [RFC 2308](https://tools.ietf.org/html/rfc2308) Negative Caching of DNS Queries (DNS NCACHE)
 * [RFC 2782](https://tools.ietf.org/html/rfc2782) A DNS RR for specifying the location of services (DNS SRV)
 * [RFC 2845](https://tools.ietf.org/html/rfc2845) Secret Key Transaction Authentication for DNS (TSIG)
+* [RFC 3596](https://tools.ietf.org/html/rfc3596) DNS Extensions to Support IP Version 6
+* `*` [RFC 4034](https://tools.ietf.org/html/rfc4034) Resource Records for the DNS Security Extensions
 * [RFC 4343](https://tools.ietf.org/html/rfc4343) Domain Name System (DNS) Case Insensitivity Clarification
-* [RFC 4398](https://tools.ietf.org/html/rfc4398) Storing Certificates in the Domain Name System (DNS)
 * [RFC 4635](https://tools.ietf.org/html/rfc4635) HMAC SHA TSIG Algorithm Identifiers
+* `*` [RFC 5001](https://tools.ietf.org/html/rfc5001) DNS Name Server Identifier (NSID) Option
 * [RFC 5358](https://tools.ietf.org/html/rfc5358) Preventing Use of Recursive Nameservers in Reflector Attacks
 * [RFC 5452](https://tools.ietf.org/html/rfc5452) Measures for Making DNS More Resilient against Forged Answers
 * [RFC 5936](https://tools.ietf.org/html/rfc5936) DNS Zone Transfer Protocol (AXFR)
+* [RFC 6761](https://tools.ietf.org/html/rfc6761) Special-Use Domain Names
+* `*` [RFC 6762](https://tools.ietf.org/html/rfc6762) Multicast DNS
 * [RFC 6844](https://tools.ietf.org/html/rfc6844) DNS Certification Authority Authorization (CAA) Resource Record
+* [RFC 6890](https://tools.ietf.org/html/rfc6890) Special-Purpose IP Address Registries
+* [RFC 6891](https://tools.ietf.org/html/rfc6891) Extension Mechanisms for DNS (EDNS(0))
 * [RFC 6895](https://tools.ietf.org/html/rfc6895) Domain Name System (DNS) IANA Considerations (BCP 42)
 * [RFC 7626](https://tools.ietf.org/html/rfc7626) DNS Privacy Considerations
 * [RFC 7766](https://tools.ietf.org/html/rfc7766) DNS Transport over TCP - Implementation Requirements
+* [RFC 7816](https://tools.ietf.org/html/rfc7816) DNS Query Name Minimisation to Improve Privacy
+* `*` [RFC 7828](https://tools.ietf.org/html/rfc7828) The edns-tcp-keepalive EDNS0 Option
+* `*` [RFC 7830](https://tools.ietf.org/html/rfc7830) The EDNS(0) Padding Option
+* `*` [RFC 7873](https://tools.ietf.org/html/rfc7873) Domain Name System (DNS) Cookies
+* [RFC 8109](https://tools.ietf.org/html/rfc8109) Initializing a DNS Resolver with Priming Queries
+* [draft-ietf-dnsop-let-localhost-be-localhost-02](https://tools.ietf.org/html/draft-ietf-dnsop-let-localhost-be-localhost-02) Let 'localhost' be localhost.
+
+`*`: Please note that the RFCs marked with `*` are only partially implemented
+(i.e. only wire format, but no logic handling the feature).
 
 ## Installation
 
-For now, you have to manually `pin` this library, since this library is not yet
-released:
+You first need to install [OCaml](https://ocaml.org) (at least 4.04.0) and
+[opam](https://opam.ocaml.org), the OCaml package manager (at least 1.2.2) on
+your machine (you can use opam to install an up-to-date OCaml (`opam switch
+4.06.0`)).  You may want to follow the [mirage installation
+instructions](https://mirage.io/wiki/install) to get `mirage` installed on your
+computer.
 
+µDNS is not released yet, but you can install it and its dependencies via opam:
 `opam pin add udns https://github.com/roburio/udns.git`
 
-There are three examples in this repository (see the `mirage/examples` directory):
-- a primary nameserver with its zone embedded in OCaml code
-- a primary nameserver where the zone is parsed at startup from a zonefile
-- a secondary nameserver
+Now the µDNS library is installed, and you can try out the examples.  For this,
+you need to clone this git repository (`git clone
+https://github.com/roburio/udns.git`) and try the provided examples
+(located in `mirage/examples`):
+- `primary` - a primary nameserver with its zone embedded in OCaml code
+- `primary-with-zone` - a primary nameserver where the zone is embedded as a zonefile
+- `secondary` - a secondary nameserver
+- `resolver` - a recursive resolver
+- `stub` - a stub resolver (with 141.1.1.1 preconfigured)
+
+In either of the directories, run `mirage configure` (see `mirage help
+configure` for options), followed by `make depend` and `make` (read more
+information [Hello MirageOS world](https://mirage.io/wiki/hello-world)).
+
+Depending on the target, the name and type of the resulting binary varies. In
+the default target, `unix`, its name is `./main.native`, and which requires
+superuser privileges to listen on port 53 (e.g. `doas ./main.native -l
+\*:debug`).
 
 ## Documentation
 

--- a/_tags
+++ b/_tags
@@ -1,32 +1,28 @@
 true : bin_annot, safe_string, principal, color(always)
 true : warn(+A-4-44)
-true : package(rresult cstruct astring fmt logs)
+true : package(rresult cstruct astring fmt ipaddr logs ptime)
 
 <mirage/examples>: -traverse
 
 <src/*> : warn_error(+1..49)
 <src/dns_enum.{ml,mli}>: package(ppx_cstruct)
-<src/dns_packet.{ml,mli}>: package(ipaddr ptime)
-<src/dns_map.{ml,mli}>: package(ipaddr)
 "src" : include
 
 <crypto/*> : warn_error(+1..49)
-<crypto/*> : package(nocrypto ptime)
+<crypto/*> : package(nocrypto)
 "crypto" : include
 
 <resolver/*> : warn_error(+1..49)
-<resolver/*> : package(duration lru ipaddr)
+<resolver/*> : package(duration lru randomconv)
 "resolver" : include
 
 <server/*> : warn_error(+1..49)
-<server/dns_server.{ml,mli}>: package(ipaddr ptime randomconv duration)
+<server/dns_server.{ml,mli}>: package(randomconv duration)
 "server" : include
 
-<zonefile/*> : package(ipaddr)
+<mirage/*> : package(mirage-types-lwt lwt duration randomconv)
 
-<mirage/*> : package(mirage-types-lwt lwt duration ptime)
-
-<test/*> : package(alcotest ipaddr ptime randomconv duration)
+<test/*> : package(alcotest randomconv duration)
 <test/tsig.{ml,native,byte}> : package(nocrypto)
 <test/resolver.{ml,native,byte}> : package(lru duration)
 

--- a/crypto/dns_tsig.mli
+++ b/crypto/dns_tsig.mli
@@ -1,4 +1,4 @@
-(* (c) 2017 Hannes Mehnert, all rights reserved *)
+(* (c) 2017, 2018 Hannes Mehnert, all rights reserved *)
 
 val compute_tsig : Dns_name.t -> Dns_packet.tsig -> key:Cstruct.t ->
   Cstruct.t -> Cstruct.t

--- a/mirage/.merlin
+++ b/mirage/.merlin
@@ -1,1 +1,0 @@
-PKG lwt mirage-stack-lwt logs udns udns.server udns.crypto mirage-types-lwt duration

--- a/mirage/dns_mirage.ml
+++ b/mirage/dns_mirage.ml
@@ -1,4 +1,4 @@
-(* (c) 2017 Hannes Mehnert, all rights reserved *)
+(* (c) 2017, 2018 Hannes Mehnert, all rights reserved *)
 
 open Mirage_types_lwt
 
@@ -17,6 +17,7 @@ module Make (R : RANDOM) (P : PCLOCK) (M : MCLOCK) (TIME : TIME) (S : STACKV4) =
   }
 
   let rec read_exactly f length =
+    let dst_ip, dst_port = T.dst f.flow in
     if Cstruct.len f.linger >= length then
       let a, b = Cstruct.split f.linger length in
       f.linger <- b ;
@@ -24,42 +25,56 @@ module Make (R : RANDOM) (P : PCLOCK) (M : MCLOCK) (TIME : TIME) (S : STACKV4) =
     else
       T.read f.flow >>= function
       | Ok `Eof ->
-        Log.warn (fun m -> m "end of file on flow") ;
+        Log.warn (fun m -> m "end of file on flow %a:%d" Ipaddr.V4.pp_hum dst_ip dst_port) ;
         T.close f.flow >>= fun () ->
         Lwt.return (Error ())
       | Error e ->
-        Log.err (fun m -> m "error reading flow %a" T.pp_error e) ;
+        Log.err (fun m -> m "error %a reading flow %a:%d" T.pp_error e Ipaddr.V4.pp_hum dst_ip dst_port) ;
         T.close f.flow >>= fun () ->
         Lwt.return (Error ())
       | Ok (`Data b) ->
         f.linger <- Cstruct.append f.linger b ;
         read_exactly f length
 
-  let send_udp udp port (dst, data) =
-    Log.info (fun m -> m "sending %d bytes udp to %a%d"
-                 (Cstruct.len data) Ipaddr.V4.pp_hum dst port) ;
-    U.write ~src_port:port ~dst ~dst_port:port udp data >|= function
-    | Error e -> Log.warn (fun m -> m "failure sending notify to %a:%d: %a"
-                              Ipaddr.V4.pp_hum dst port U.pp_error e)
+  let send_udp stack src_port dst dst_port data =
+    Log.info (fun m -> m "udp: sending %d bytes from %d to %a:%d"
+                 (Cstruct.len data) src_port Ipaddr.V4.pp_hum dst dst_port) ;
+    U.write ~src_port ~dst ~dst_port (S.udpv4 stack) data >|= function
+    | Error e -> Log.warn (fun m -> m "udp: failure %a while sending from %d to %a:%d"
+                              U.pp_error e src_port Ipaddr.V4.pp_hum dst dst_port)
     | Ok () -> ()
+
+  let send_tcp flow answer =
+    let dst_ip, dst_port = T.dst flow in
+    Log.info (fun m -> m "tcp: sending %d bytes to %a:%d" (Cstruct.len answer) Ipaddr.V4.pp_hum dst_ip dst_port) ;
+    let len = Cstruct.create 2 in
+    Cstruct.BE.set_uint16 len 0 (Cstruct.len answer) ;
+    T.write flow (Cstruct.append len answer) >>= function
+    | Ok () -> Lwt.return (Ok ())
+    | Error e ->
+      Log.err (fun m -> m "tcp: error %a while writing to %a:%d" T.pp_write_error e Ipaddr.V4.pp_hum dst_ip dst_port) ;
+      T.close flow >|= fun () ->
+      Error ()
+
+  let read_tcp flow =
+    read_exactly flow 2 >>= function
+    | Error () -> Lwt.return (Error ())
+    | Ok l ->
+      let len = Cstruct.BE.get_uint16 l 0 in
+      read_exactly flow len
 
   let primary stack pclock mclock ?(timer = 2) ?(port = 53) t =
     let state = ref t in
-    let send_notify = send_udp (S.udpv4 stack) port in
+    let send_notify (ip, data) = send_udp stack port ip port data in
     let udp_cb ~src ~dst ~src_port buf =
       Log.info (fun m -> m "udp frame from %a:%d" Ipaddr.V4.pp_hum src src_port) ;
-      Log.debug (fun m -> m "received:@.%a" Cstruct.hexdump_pp buf) ;
       let now = Ptime.v (P.now_d_ps pclock) in
       let elapsed = M.elapsed_ns mclock in
       let t, answer, notify = Dns_server.Primary.handle !state now elapsed `Udp src buf in
       state := t ;
       (match answer with
        | None -> Log.warn (fun m -> m "empty answer") ; Lwt.return_unit
-       | Some answer ->
-         Log.info (fun m -> m "udp sending %d bytes to %a:%d" (Cstruct.len answer) Ipaddr.V4.pp_hum src src_port) ;
-         (U.write ~src_port:port ~dst:src ~dst_port:src_port (S.udpv4 stack) answer >|= function
-           | Error e -> Log.warn (fun m -> m "failure sending reply: %a" U.pp_error e)
-           | Ok () -> ())) >>= fun () ->
+       | Some answer -> send_udp stack port src src_port answer) >>= fun () ->
       Lwt_list.iter_p send_notify notify
     in
     S.listen_udpv4 stack ~port udp_cb ;
@@ -69,81 +84,66 @@ module Make (R : RANDOM) (P : PCLOCK) (M : MCLOCK) (TIME : TIME) (S : STACKV4) =
       Log.info (fun m -> m "tcp connection from %a:%d" Ipaddr.V4.pp_hum dst_ip dst_port) ;
       let f = { flow ; linger = Cstruct.create 0 } in
       let rec loop () =
-        read_exactly f 2 >>= function
-        | Error _ -> Lwt.return_unit
-        | Ok l ->
-          let len = Cstruct.BE.get_uint16 l 0 in
-          read_exactly f len >>= function
-          | Error _ -> Lwt.return_unit
-          | Ok data ->
-            let now = Ptime.v (P.now_d_ps pclock) in
-            let elapsed = M.elapsed_ns mclock in
-            let t, answer, notify = Dns_server.Primary.handle !state now elapsed `Tcp dst_ip data in
-            state := t ;
-            Lwt_list.iter_p send_notify notify >>= fun () ->
-            match answer with
-            | None -> Log.warn (fun m -> m "empty answer") ; loop ()
-            | Some answer ->
-              Log.info (fun m -> m "tcp: sending %d bytes to %a:%d" (Cstruct.len answer) Ipaddr.V4.pp_hum dst_ip dst_port) ;
-              let len = Cstruct.create 2 in
-              Cstruct.BE.set_uint16 len 0 (Cstruct.len answer) ;
-              T.write flow (Cstruct.append len answer) >>= function
-              | Ok () -> loop ()
-              | Error e ->
-                Log.err (fun m -> m "error while writing %a" T.pp_write_error e) ;
-                T.close flow
+        read_tcp f >>= function
+        | Error () -> Lwt.return_unit
+        | Ok data ->
+          let now = Ptime.v (P.now_d_ps pclock) in
+          let elapsed = M.elapsed_ns mclock in
+          let t, answer, notify = Dns_server.Primary.handle !state now elapsed `Tcp dst_ip data in
+          state := t ;
+          Lwt_list.iter_p send_notify notify >>= fun () ->
+          match answer with
+          | None -> Log.warn (fun m -> m "empty answer") ; loop ()
+          | Some answer ->
+            send_tcp flow answer >>= function
+            | Ok () -> loop ()
+            | Error () -> Lwt.return_unit
       in
       loop ()
     in
     S.listen_tcpv4 stack ~port tcp_cb ;
     Log.info (fun m -> m "DNS server listening on TCP port %d" port) ;
-    let zzz = Duration.of_sec timer in
-    let rec timer () =
+    let rec time () =
       let t, notifies = Dns_server.Primary.timer !state (M.elapsed_ns mclock) in
       state := t ;
       Lwt_list.iter_p send_notify notifies >>= fun () ->
-      TIME.sleep_ns zzz >>= fun () ->
-      timer ()
+      TIME.sleep_ns (Duration.of_sec timer) >>= fun () ->
+      time ()
     in
-    Lwt.async timer
+    Lwt.async time
 
   let secondary stack pclock mclock ?(timer = 300) ?(port = 53) t =
     let state = ref t in
     let send (proto, ip, data) =
       match proto with
-      | `Udp -> send_udp (S.udpv4 stack) port (ip, data)
+      | `Udp -> send_udp stack port ip port data
       | `Tcp ->
         Lwt.async (fun () ->
-            Log.info (fun m -> m "tcp sending %d bytes to %a@.%a" (Cstruct.len data) Ipaddr.V4.pp_hum ip Cstruct.hexdump_pp data) ;
             T.create_connection (S.tcpv4 stack) (ip, port) >>= function
-            | Error e -> Log.err (fun m -> m "error %a while establishing connection" T.pp_error e) ; Lwt.return_unit
+            | Error e ->
+              Log.err (fun m -> m "error %a while establishing tcp connection to %a:%d"
+                          T.pp_error e Ipaddr.V4.pp_hum ip port) ;
+              Lwt.return_unit
             | Ok flow ->
-              let len = Cstruct.create 2 in
-              Cstruct.BE.set_uint16 len 0 (Cstruct.len data) ;
-              T.write flow (Cstruct.append len data) >>= function
-              | Error e -> Log.err (fun m -> m "error while writing %a" T.pp_write_error e) ; Lwt.return_unit
+              send_tcp flow data >>= function
+              | Error () -> Lwt.return_unit
               | Ok () ->
                 let f = { flow ; linger = Cstruct.create 0 } in
-                read_exactly f 2 >>= function
-                | Error _ -> Lwt.return_unit
-                | Ok l ->
-                  let len = Cstruct.BE.get_uint16 l 0 in
-                  read_exactly f len >>= function
-                  | Error _ -> Lwt.return_unit
-                  | Ok data ->
-                    let now = Ptime.v (P.now_d_ps pclock) in
-                    let elapsed = M.elapsed_ns mclock in
-                    let t, answer, out = Dns_server.Secondary.handle !state now elapsed `Tcp ip data in
-                    state := t ;
-                    (* assume that answer and out are empty *)
-                    (match answer with Some _ -> Log.err (fun m -> m "expected no answer") | None -> ()) ;
-                    (match out with [] -> () | _ -> Log.err (fun m -> m "expected no out")) ;
-                    T.close flow) ;
+                read_tcp f >>= function
+                | Error () -> Lwt.return_unit
+                | Ok data ->
+                  let now = Ptime.v (P.now_d_ps pclock) in
+                  let elapsed = M.elapsed_ns mclock in
+                  let t, answer, out = Dns_server.Secondary.handle !state now elapsed `Tcp ip data in
+                  state := t ;
+                  (* assume that answer and out are empty *)
+                  (match answer with Some _ -> Log.err (fun m -> m "expected no answer") | None -> ()) ;
+                  (match out with [] -> () | _ -> Log.err (fun m -> m "expected no out")) ;
+                  T.close flow) ;
         Lwt.return_unit
     in
     let udp_cb ~src ~dst ~src_port buf =
       Log.info (fun m -> m "udp frame from %a:%d" Ipaddr.V4.pp_hum src src_port) ;
-      Log.debug (fun m -> m "received:@.%a" Cstruct.hexdump_pp buf) ;
       let now = Ptime.v (P.now_d_ps pclock) in
       let elapsed = M.elapsed_ns mclock in
       let t, answer, out = Dns_server.Secondary.handle !state now elapsed `Udp src buf in
@@ -151,11 +151,7 @@ module Make (R : RANDOM) (P : PCLOCK) (M : MCLOCK) (TIME : TIME) (S : STACKV4) =
       Lwt_list.iter_p send out >>= fun () ->
       match answer with
       | None -> Lwt.return_unit
-      | Some out ->
-        Log.info (fun m -> m "udp sending %d bytes to %a:%d" (Cstruct.len out) Ipaddr.V4.pp_hum src src_port) ;
-        U.write ~src_port:port ~dst:src ~dst_port:src_port (S.udpv4 stack) out >|= function
-        | Error e -> Log.warn (fun m -> m "failure sending reply: %a" U.pp_error e)
-        | Ok () -> ()
+      | Some out -> send_udp stack port src src_port out
     in
     S.listen_udpv4 stack ~port udp_cb ;
     Log.info (fun m -> m "secondary DNS listening on UDP port %d" port) ;
@@ -164,45 +160,193 @@ module Make (R : RANDOM) (P : PCLOCK) (M : MCLOCK) (TIME : TIME) (S : STACKV4) =
       Log.info (fun m -> m "tcp connection from %a:%d" Ipaddr.V4.pp_hum dst_ip dst_port) ;
       let f = { flow ; linger = Cstruct.create 0 } in
       let rec loop () =
-        read_exactly f 2 >>= function
-        | Error _ -> Lwt.return_unit
-        | Ok l ->
-          let len = Cstruct.BE.get_uint16 l 0 in
-          read_exactly f len >>= function
-          | Error _ -> Lwt.return_unit
-          | Ok data ->
-            let now = Ptime.v (P.now_d_ps pclock) in
-            let elapsed = M.elapsed_ns mclock in
-            let t, answer, out = Dns_server.Secondary.handle !state now elapsed `Tcp dst_ip data in
-            state := t ;
-            Lwt_list.iter_p send out >>= fun () ->
-            match answer with
-            | None ->
-              Log.warn (fun m -> m "no TCP output") ;
-              loop ()
-            | Some data ->
-              Log.info (fun m -> m "sending answer %d bytes via tcp to %a:%d" (Cstruct.len data) Ipaddr.V4.pp_hum dst_ip dst_port) ;
-              let len = Cstruct.create 2 in
-              Cstruct.BE.set_uint16 len 0 (Cstruct.len data) ;
-              T.write flow (Cstruct.append len data) >>= function
-              | Ok () -> loop ()
-              | Error e ->
-                Log.err (fun m -> m "error while writing %a" T.pp_write_error e) ;
-                T.close flow
+        read_tcp f >>= function
+        | Error () -> Lwt.return_unit
+        | Ok data ->
+          let now = Ptime.v (P.now_d_ps pclock) in
+          let elapsed = M.elapsed_ns mclock in
+          let t, answer, out = Dns_server.Secondary.handle !state now elapsed `Tcp dst_ip data in
+          state := t ;
+          Lwt_list.iter_p send out >>= fun () ->
+          match answer with
+          | None ->
+            Log.warn (fun m -> m "no TCP output") ;
+            loop ()
+          | Some data ->
+            send_tcp flow data >>= function
+            | Ok () -> loop ()
+            | Error () -> Lwt.return_unit
       in
       loop ()
     in
     S.listen_tcpv4 stack ~port tcp_cb ;
     Log.info (fun m -> m "secondary DNS listening on TCP port %d" port) ;
-    let zzz = Duration.of_sec timer in
-    let rec timer () =
+    let rec time () =
       let now = Ptime.v (P.now_d_ps pclock) in
       let elapsed = M.elapsed_ns mclock in
       let t, out = Dns_server.Secondary.timer !state now elapsed in
       state := t ;
       Lwt_list.iter_p send out >>= fun () ->
-      TIME.sleep_ns zzz >>= fun () ->
-      timer ()
+      TIME.sleep_ns (Duration.of_sec timer) >>= fun () ->
+      time ()
     in
-    Lwt.async timer
+    Lwt.async time
+
+  module FM = Map.Make(struct
+      type t = Ipaddr.V4.t * int
+      let compare (ip, p) (ip', p') =
+        match Ipaddr.V4.compare ip ip' with
+        | 0 -> compare p p'
+        | x -> x
+    end)
+
+  module IM = Map.Make(Ipaddr.V4)
+
+  let resolver stack pclock mclock ?(root = false) ?(timer = 500) ?(port = 53) t =
+    (* according to RFC5452 4.5, we can chose source port between 1024-49152 *)
+    let sport () = 1024 + Randomconv.int ~bound:48128 R.generate in
+    let state = ref t in
+    let tcp_in = ref FM.empty in
+    let tcp_out = ref IM.empty in
+
+    let rec client_out dst port =
+      T.create_connection (S.tcpv4 stack) (dst, port) >>= function
+      | Error e ->
+        (* do i need to report this back into the resolver? what are their options then? *)
+        Log.err (fun m -> m "error %a while establishing tcp connection to %a:%d"
+                    T.pp_error e Ipaddr.V4.pp_hum dst port) ;
+        Lwt.return (Error ())
+      | Ok flow ->
+        Logs.info (fun m -> m "established new outgoing TCP connection to %a:%d"
+                      Ipaddr.V4.pp_hum dst port);
+        tcp_out := IM.add dst flow !tcp_out ;
+        Lwt.async (fun () ->
+            let f = { flow ; linger = Cstruct.create 0 } in
+            let rec loop () =
+              read_tcp f >>= function
+              | Error () ->
+                Logs.info (fun m -> m "removing %a from tcp_out" Ipaddr.V4.pp_hum dst) ;
+                tcp_out := IM.remove dst !tcp_out ;
+                Lwt.return_unit
+              | Ok data ->
+                let now = Ptime.v (P.now_d_ps pclock) in
+                let ts = M.elapsed_ns mclock in
+                let new_state, answers, queries =
+                  Dns_resolver.handle !state now ts `Tcp dst port data
+                in
+                state := new_state ;
+                Lwt_list.iter_p handle_answer answers >>= fun () ->
+                Lwt_list.iter_p handle_query queries >>= fun () ->
+                loop ()
+            in
+            loop ()) ;
+        Lwt.return (Ok flow)
+    and client_tcp dst port data =
+      match try Some (IM.find dst !tcp_out) with Not_found -> None with
+      | None ->
+        begin
+          client_out dst port >>= function
+          | Error () ->
+            let sport = sport () in
+            S.listen_udpv4 stack ~port:sport udp_cb ;
+            send_udp stack sport dst port data
+          | Ok flow -> client_tcp dst port data
+        end
+      | Some x ->
+        send_tcp x data >>= function
+        | Ok () -> Lwt.return_unit
+        | Error () ->
+          tcp_out := IM.remove dst !tcp_out ;
+          client_tcp dst port data
+    and maybe_tcp dst port data =
+      (try
+         let flow = IM.find dst !tcp_out in
+         send_tcp flow data
+       with Not_found -> Lwt.return (Error ())) >>= function
+      | Ok () -> Lwt.return_unit
+      | Error () ->
+        let sport = sport () in
+        S.listen_udpv4 stack ~port:sport udp_cb ;
+        send_udp stack sport dst port data
+    and handle_query (proto, dst, data) = match proto with
+      | `Udp -> maybe_tcp dst port data
+      | `Tcp -> client_tcp dst port data
+    and handle_answer (proto, dst, dst_port, data) = match proto with
+      | `Udp -> send_udp stack port dst dst_port data
+      | `Tcp -> match try Some (FM.find (dst, dst_port) !tcp_in) with Not_found -> None with
+        | None ->
+          Logs.err (fun m -> m "wanted to answer %a:%d via TCP, but couldn't find a flow"
+                       Ipaddr.V4.pp_hum dst dst_port) ;
+          Lwt.return_unit
+        | Some flow -> send_tcp flow data >|= function
+          | Ok () -> ()
+          | Error () -> tcp_in := FM.remove (dst, dst_port) !tcp_in
+    and udp_cb ~src ~dst ~src_port buf =
+      let now = Ptime.v (P.now_d_ps pclock)
+      and ts = M.elapsed_ns mclock
+      in
+      let new_state, answers, queries =
+        Dns_resolver.handle !state now ts `Udp src src_port buf
+      in
+      state := new_state ;
+      Lwt_list.iter_p handle_answer answers >>= fun () ->
+      Lwt_list.iter_p handle_query queries
+    in
+    S.listen_udpv4 stack ~port udp_cb ;
+    Logs.app (fun f -> f "DNS resolver listening on UDP port %d" port);
+
+    let tcp_cb flow =
+      let dst_ip, dst_port = T.dst flow in
+      Log.info (fun m -> m "tcp connection from %a:%d" Ipaddr.V4.pp_hum dst_ip dst_port) ;
+      tcp_in := FM.add (dst_ip, dst_port) flow !tcp_in ;
+      let f = { flow ; linger = Cstruct.create 0 } in
+      let rec loop () =
+        read_tcp f >>= function
+        | Error () ->
+          tcp_in := FM.remove (dst_ip, dst_port) !tcp_in ;
+          Lwt.return_unit
+        | Ok data ->
+          let now = Ptime.v (P.now_d_ps pclock) in
+          let ts = M.elapsed_ns mclock in
+          let new_state, answers, queries =
+            Dns_resolver.handle !state now ts `Tcp dst_ip dst_port data
+          in
+          state := new_state ;
+          Lwt_list.iter_p handle_answer answers >>= fun () ->
+          Lwt_list.iter_p handle_query queries >>= fun () ->
+          loop ()
+      in
+      loop ()
+    in
+    S.listen_tcpv4 stack ~port tcp_cb ;
+    Log.info (fun m -> m "DNS resolver listening on TCP port %d" port) ;
+
+    let rec stats_reporter () =
+      Dns_resolver.stats !state ;
+      TIME.sleep_ns (Duration.of_min 5) >>= fun () ->
+      stats_reporter ()
+    in
+    Lwt.async stats_reporter ;
+
+    let rec time () =
+      let new_state, answers, queries =
+        Dns_resolver.timer !state (M.elapsed_ns mclock)
+      in
+      state := new_state ;
+      Lwt_list.iter_p handle_answer answers >>= fun () ->
+      Lwt_list.iter_p handle_query queries >>= fun () ->
+      TIME.sleep_ns (Duration.of_ms timer) >>= fun () ->
+      time ()
+    in
+    Lwt.async time ;
+
+    if root then
+      let rec root () =
+        let new_state, q = Dns_resolver.query_root !state (M.elapsed_ns mclock) `Tcp in
+        state := new_state ;
+        handle_query q >>= fun () ->
+        TIME.sleep_ns (Duration.of_day 6) >>= fun () ->
+        root ()
+      in
+      Lwt.async root
 end

--- a/mirage/dns_mirage.mli
+++ b/mirage/dns_mirage.mli
@@ -1,10 +1,13 @@
-(* (c) 2017 Hannes Mehnert, all rights reserved *)
+(* (c) 2017, 2018 Hannes Mehnert, all rights reserved *)
 
 open Mirage_types_lwt
 
 module Make (R : RANDOM) (P : PCLOCK) (M : MCLOCK) (T : TIME) (S : STACKV4) : sig
 
-  val primary : S.t -> P.t -> M.t -> ?timer:int -> ?port:int -> Dns_server.Primary.t -> unit
+  val primary : S.t -> P.t -> M.t -> ?timer:int -> ?port:int -> Dns_server.Primary.s -> unit
 
-  val secondary : S.t -> P.t -> M.t -> ?timer:int -> ?port:int -> Dns_server.Secondary.t -> unit
+  val secondary : S.t -> P.t -> M.t -> ?timer:int -> ?port:int -> Dns_server.Secondary.s -> unit
+
+  val resolver : S.t -> P.t -> M.t -> ?root:bool -> ?timer:int -> ?port:int -> Dns_resolver.t -> unit
+
 end

--- a/mirage/examples/primary-with-zone/config.ml
+++ b/mirage/examples/primary-with-zone/config.ml
@@ -1,4 +1,4 @@
-(* (c) 2017 Hannes Mehnert, all rights reserved *)
+(* (c) 2017, 2018 Hannes Mehnert, all rights reserved *)
 
 open Mirage
 

--- a/mirage/examples/primary-with-zone/unikernel.ml
+++ b/mirage/examples/primary-with-zone/unikernel.ml
@@ -1,4 +1,4 @@
-(* (c) 2017 Hannes Mehnert, all rights reserved *)
+(* (c) 2017, 2018 Hannes Mehnert, all rights reserved *)
 
 open Lwt.Infix
 

--- a/mirage/examples/primary/config.ml
+++ b/mirage/examples/primary/config.ml
@@ -1,4 +1,4 @@
-(* (c) 2017 Hannes Mehnert, all rights reserved *)
+(* (c) 2017, 2018 Hannes Mehnert, all rights reserved *)
 
 open Mirage
 

--- a/mirage/examples/primary/unikernel.ml
+++ b/mirage/examples/primary/unikernel.ml
@@ -1,4 +1,4 @@
-(* (c) 2017 Hannes Mehnert, all rights reserved *)
+(* (c) 2017, 2018 Hannes Mehnert, all rights reserved *)
 
 open Lwt.Infix
 
@@ -28,15 +28,23 @@ module Main (R : RANDOM) (P : PCLOCK) (M : MCLOCK) (T : TIME) (S : STACKV4) = st
     let t = insert (n "mirage") (V (K.Ns, (ttl, s ns, Dns_name.DomMap.empty))) t in
     let t = insert (n "nuc.mirage") (V (K.A, (ttl, [ ip "10.0.0.1" ]))) t in
     let t = insert ns (V (K.A, (ttl, [ ip "10.0.0.2" ]))) t in
-    let t = insert (n "charrua.mirage") (V (K.A, (ttl, [ ip "10.0.0.5" ]))) t in
-    let t = insert (n "resolver.mirage") (V (K.Cname, (ttl, n "cname2.example"))) t in
-    let key = Cstruct.of_string  "vig6XSd5HUDh79UQrdS3qfO5/rfMcNofhzQGtEQpyHs=" in
-    let t = insert (Dns_name.of_string_exn ~hostname:false "key._transfer.example")
-        (V (K.Dnskey, [ { Dns_packet.flags = 0 ; key_algorithm = Dns_enum.SHA256 ; key } ])) t
+    let t = insert (n "charrua.mirage") (V (K.A, (ttl, [ ip "10.0.0.3" ]))) t in
+    let t = insert (n "resolver.mirage") (V (K.A, (ttl, [ ip "10.0.0.5" ]))) t in
+    let t = insert (n "www.mirage") (V (K.Cname, (ttl, n "nuc.mirage"))) t in
+    let key_algorithm = Dns_enum.SHA256
+    and flags = 0
     in
-    let key = Cstruct.of_string "eEc/4kAwnhNXAcKrfyyC13NeVG2CkBaHRrYbDoUVDOE=" in
-    let t = insert (Dns_name.of_string_exn ~hostname:false "one._update.example")
-        (V (K.Dnskey, [ { Dns_packet.flags = 0 ; key_algorithm = Dns_enum.SHA256 ; key } ])) t
+    let key = Cstruct.of_string "/WcnjpqrErYrXi1dd4sv8dfwCwDFg0ZGm6N6Bq1VwMI=" in
+    let t = insert (Dns_name.of_string_exn ~hostname:false "key._transfer.mirage")
+        (V (K.Dnskey, [ { Dns_packet.flags ; key_algorithm ; key } ])) t
+    in
+    let key = Cstruct.of_string "eRhj4OoaGIIJ3I9hJFwYGhAkdiR5DNzia0WoGrYy70k=" in
+    let t = insert (Dns_name.of_string_exn ~hostname:false "one._update.mirage")
+        (V (K.Dnskey, [ { Dns_packet.flags ; key_algorithm ; key } ])) t
+    in
+    let key = Cstruct.of_string "/NzgCgIc4yKa7nZvWmODrHMbU+xpMeGiDLkZJGD/Evo=" in
+    let t = insert (Dns_name.of_string_exn ~hostname:false "foo._key-management")
+        (V (K.Dnskey, [ { Dns_packet.flags ; key_algorithm ; key } ])) t
     in
     t
 

--- a/mirage/examples/resolver/config.ml
+++ b/mirage/examples/resolver/config.ml
@@ -1,0 +1,31 @@
+(* (c) 2017, 2018 Hannes Mehnert, all rights reserved *)
+
+open Mirage
+
+let address =
+  let network = Ipaddr.V4.Prefix.of_address_string_exn "10.0.42.5/24"
+  and gateway = Ipaddr.V4.of_string "10.0.42.1"
+  in
+  { network ; gateway }
+
+let net =
+  if_impl Key.is_unix
+    (socket_stackv4 [Ipaddr.V4.any])
+    (static_ipv4_stack ~config:address ~arp:farp default_network)
+
+let dns_handler =
+  let packages = [
+    package "logs" ;
+    package ~sublibs:["resolver";"server";"crypto";"mirage"] "udns" ;
+    package "randomconv" ;
+    package "lru" ;
+    package "rresult" ;
+    package "duration" ;
+  ] in
+  foreign
+    ~deps:[abstract nocrypto]
+    ~packages
+    "Unikernel.Main" (random @-> pclock @-> mclock @-> time @-> stackv4 @-> job)
+
+let () =
+  register "resolver" [dns_handler $ default_random $ default_posix_clock $ default_monotonic_clock $ default_time $ net ]

--- a/mirage/examples/resolver/unikernel.ml
+++ b/mirage/examples/resolver/unikernel.ml
@@ -1,0 +1,43 @@
+(* (c) 2017, 2018 Hannes Mehnert, all rights reserved *)
+
+open Lwt.Infix
+
+open Mirage_types_lwt
+
+module Main (R : RANDOM) (P : PCLOCK) (M : MCLOCK) (T : TIME) (S : STACKV4) = struct
+  module D = Dns_mirage.Make(R)(P)(M)(T)(S)
+
+  let start _r pclock mclock _ s _ =
+    let key = Cstruct.of_string "/NzgCgIc4yKa7nZvWmODrHMbU+xpMeGiDLkZJGD/Evo=" in
+    let trie =
+      Dns_trie.insert (Dns_name.of_string_exn ~hostname:false "foo._key-management")
+        (Dns_map.V (Dns_map.K.Dnskey, [ { Dns_packet.flags = 0 ; key_algorithm = Dns_enum.SHA256 ; key } ]))
+        Dns_trie.empty
+    in
+    let trie =
+      let inv s =
+        let soa = { Dns_packet.nameserver = s ; hostmaster = s ;
+                    serial = 0l ; refresh = 300l ; retry = 300l ;
+                    expiry = 300l ; minimum = 300l }
+        in
+        Dns_map.(V (K.Soa, (300l, soa)))
+      in
+      Dns_name.DomSet.fold
+        (fun n trie -> Dns_trie.insert n (inv n) trie)
+        Dns_resolver_root.reserved_zones
+        trie
+    in
+    (match Dns_trie.check trie with
+     | Ok () -> ()
+     | Error e ->
+       Logs.err (fun m -> m "check after update returned %a" Dns_trie.pp_err e)) ;
+    let now = M.elapsed_ns mclock in
+    let server =
+      Dns_server.Primary.create now ~a:[Dns_server.tsig_auth]
+        ~tsig_verify:Dns_tsig.verify ~tsig_sign:Dns_tsig.sign ~rng:R.generate
+        trie
+    in
+    let p = Dns_resolver.create ~root:true now R.generate server () in
+    D.resolver s pclock mclock p ;
+    S.listen s
+end

--- a/mirage/examples/secondary/config.ml
+++ b/mirage/examples/secondary/config.ml
@@ -1,4 +1,4 @@
-(* (c) 2017 Hannes Mehnert, all rights reserved *)
+(* (c) 2017, 2018 Hannes Mehnert, all rights reserved *)
 
 open Mirage
 

--- a/mirage/examples/secondary/unikernel.ml
+++ b/mirage/examples/secondary/unikernel.ml
@@ -1,4 +1,4 @@
-(* (c) 2017 Hannes Mehnert, all rights reserved *)
+(* (c) 2017, 2018 Hannes Mehnert, all rights reserved *)
 
 open Lwt.Infix
 

--- a/mirage/examples/stub/config.ml
+++ b/mirage/examples/stub/config.ml
@@ -1,0 +1,31 @@
+(* (c) 2017, 2018 Hannes Mehnert, all rights reserved *)
+
+open Mirage
+
+let address =
+  let network = Ipaddr.V4.Prefix.of_address_string_exn "10.0.42.6/24"
+  and gateway = Ipaddr.V4.of_string "10.0.42.1"
+  in
+  { network ; gateway }
+
+let net =
+  if_impl Key.is_unix
+    (socket_stackv4 [Ipaddr.V4.any])
+    (static_ipv4_stack ~config:address ~arp:farp default_network)
+
+let dns_handler =
+  let packages = [
+    package "logs" ;
+    package ~sublibs:["resolver";"server";"crypto";"mirage"] "udns" ;
+    package "randomconv" ;
+    package "lru" ;
+    package "rresult" ;
+    package "duration" ;
+  ] in
+  foreign
+    ~deps:[abstract nocrypto]
+    ~packages
+    "Unikernel.Main" (random @-> pclock @-> mclock @-> time @-> stackv4 @-> job)
+
+let () =
+  register "stub" [dns_handler $ default_random $ default_posix_clock $ default_monotonic_clock $ default_time $ net ]

--- a/mirage/examples/stub/unikernel.ml
+++ b/mirage/examples/stub/unikernel.ml
@@ -1,0 +1,53 @@
+(* (c) 2017, 2018 Hannes Mehnert, all rights reserved *)
+
+open Lwt.Infix
+
+open Mirage_types_lwt
+
+module Main (R : RANDOM) (P : PCLOCK) (M : MCLOCK) (T : TIME) (S : STACKV4) = struct
+  module D = Dns_mirage.Make(R)(P)(M)(T)(S)
+
+  let start _r pclock mclock _ s _ =
+    let key = Cstruct.of_string "/NzgCgIc4yKa7nZvWmODrHMbU+xpMeGiDLkZJGD/Evo=" in
+    let trie =
+      Dns_trie.insert (Dns_name.of_string_exn ~hostname:false "foo._key-management")
+        (Dns_map.V (Dns_map.K.Dnskey, [ { Dns_packet.flags = 0 ; key_algorithm = Dns_enum.SHA256 ; key } ]))
+        Dns_trie.empty
+    in
+    let trie =
+      let inv s =
+        let soa = { Dns_packet.nameserver = s ; hostmaster = s ;
+                    serial = 0l ; refresh = 300l ; retry = 300l ;
+                    expiry = 300l ; minimum = 300l }
+        in
+        Dns_map.(V (K.Soa, (300l, soa)))
+      in
+      Dns_name.DomSet.fold
+        (fun n trie -> Dns_trie.insert n (inv n) trie)
+        Dns_resolver_root.reserved_zones
+        trie
+    in
+    let trie =
+      let name = Dns_name.of_string_exn "resolver"
+      and ip = Ipaddr.V4.of_string_exn "141.1.1.1"
+      in
+      let trie =
+        Dns_trie.insert Dns_name.root
+          Dns_map.(V (K.Ns, (300l, Dns_name.DomSet.singleton name))) trie
+      in
+      Dns_trie.insert name Dns_map.(V (K.A, (300l, [ ip ]))) trie
+    in
+    (match Dns_trie.check trie with
+     | Ok () -> ()
+     | Error e ->
+       Logs.err (fun m -> m "check after update returned %a" Dns_trie.pp_err e)) ;
+    let now = M.elapsed_ns mclock in
+    let server =
+      Dns_server.Primary.create now ~a:[Dns_server.tsig_auth]
+        ~tsig_verify:Dns_tsig.verify ~tsig_sign:Dns_tsig.sign ~rng:R.generate
+        trie
+    in
+    let p = Dns_resolver.create now R.generate server () in
+    D.resolver s pclock mclock p ;
+    S.listen s
+end

--- a/opam
+++ b/opam
@@ -5,6 +5,7 @@ homepage: "https://github.com/roburio/udns"
 doc: "https://roburio.github.io/udns/doc"
 dev-repo: "https://github.com/roburio/udns.git"
 bug-reports: "https://github.com/roburio/udns/issues"
+license: "BSD2"
 available: [ ocaml-version >= "4.04.0"]
 
 depends: [

--- a/pkg/META
+++ b/pkg/META
@@ -39,21 +39,21 @@ package "zonefile" (
  exists_if = "udns_zonefile.cma"
 )
 
-#package "resolver" (
-# version = "%%VERSION_NUM%%"
-# description = "Recursive DNS resolver"
-# requires = "udns lru duration"
-# archive(byte) = "udns_resolver.cma"
-# plugin(byte) = "udns_resolver.cma"
-# archive(native) = "udns_resolver.cmxa"
-# plugin(native) = "udns_resolver.cmxs"
-# exists_if = "udns_resolver.cma"
-#)
+package "resolver" (
+ version = "%%VERSION_NUM%%"
+ description = "Recursive DNS resolver"
+ requires = "udns udns.server lru duration randomconv"
+ archive(byte) = "udns_resolver.cma"
+ plugin(byte) = "udns_resolver.cma"
+ archive(native) = "udns_resolver.cmxa"
+ plugin(native) = "udns_resolver.cmxs"
+ exists_if = "udns_resolver.cma"
+)
 
 package "mirage" (
  version = "%%VERSION_NUM%%"
  description = "effectful MirageOS DNS layer"
- requires = "udns udns.server mirage-types-lwt"
+ requires = "udns udns.server udns.resolver mirage-types-lwt lwt duration randomconv"
  archive(byte) = "udns_mirage.cma"
  plugin(byte) = "udns_mirage.cma"
  archive(native) = "udns_mirage.cmxa"

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -23,11 +23,11 @@ let () =
     Pkg.mllib "crypto/udns_crypto.mllib" ;
     Pkg.mllib "server/udns_server.mllib" ;
     Pkg.mllib ~api:["Zonefile"] "zonefile/udns_zonefile.mllib" ;
-    (* Pkg.mllib "resolver/udns_resolver.mllib" ; *)
+    Pkg.mllib "resolver/udns_resolver.mllib" ;
     Pkg.mllib "mirage/udns_mirage.mllib" ;
     Pkg.test "test/tests" ;
     Pkg.test "test/tsig" ;
-    (* Pkg.test "test/resolver" ; *)
+    Pkg.test "test/resolver" ;
     Pkg.test "test/server" ;
     (* Pkg.test ~run:false "test/afl" *)
     Pkg.test ~run:false "test/bench" ;

--- a/resolver/dns_resolver.ml
+++ b/resolver/dns_resolver.ml
@@ -1,0 +1,565 @@
+(* (c) 2017, 2018 Hannes Mehnert, all rights reserved *)
+
+(* The cache (a Map!?) for answers: once a specific type/name comes in, we know
+   which questions can progress now *)
+module K = struct
+  type t = Dns_enum.rr_typ * Dns_name.t
+
+  let compare (t, n) (t', n') = match Dns_name.compare n n' with
+    | 0 -> compare (Dns_enum.rr_typ_to_int t) (Dns_enum.rr_typ_to_int t')
+    | x -> x
+end
+
+module QM = Map.Make(K)
+
+type awaiting = int64 * int * Dns_packet.proto * Dns_packet.opts option * Ipaddr.V4.t * int * Dns_packet.question * int
+
+open Rresult.R.Infix
+
+let retry_interval = Duration.of_ms 500
+
+type stats = {
+  questions : int ;
+  responses : int ;
+  answers : int ;
+  authoritative : int ;
+  delegation : int ;
+  errors : int ;
+  drops : int ;
+  retransmits : int ;
+  total_out : int ;
+  max_out : int ;
+  total_time : int64 ;
+  max_time : int64 ;
+  drop_timeout : int ;
+  drop_send : int ;
+  retry_edns : int ;
+  tcp_upgrade : int ;
+}
+
+let empty_stats () = {
+  questions = 0 ; responses = 0 ; answers = 0 ;
+  authoritative = 0 ; delegation = 0 ;
+  errors = 0 ; drops = 0 ; retransmits = 0 ;
+  total_out = 0 ; max_out = 0 ; drop_timeout = 0 ; drop_send = 0 ;
+  retry_edns = 0 ; total_time = 0L ; max_time = 0L ; tcp_upgrade = 0 ;
+}
+
+let s = ref (empty_stats ())
+
+let pp_stats pf s =
+  let avg = if s.answers = 0 then 0L else Int64.div s.total_time (Int64.of_int s.answers) in
+  let avg_out = if s.answers = 0 then 0. else float_of_int s.total_out /. float_of_int s.answers in
+  Fmt.pf pf "%d questions, %d answers max %a (avg %a)@.%d received responses, %d authoritative, %d delegations, %d errors, %d dropped replies, %d retransmits, %d noedns retries, %d tcp upgrade@.%f average out (%d max), %d timeout drops %d max_out drops"
+    s.questions s.answers Duration.pp s.max_time Duration.pp avg s.responses s.authoritative s.delegation s.errors s.drops s.retransmits s.retry_edns s.tcp_upgrade avg_out s.max_out s.drop_timeout s.drop_send
+
+type t = {
+  rng : int -> Cstruct.t ;
+  primary : Dns_server.Primary.s ;
+  cache : Dns_resolver_cache.t ;
+  transit : awaiting QM.t ;
+  queried : awaiting list QM.t ;
+}
+
+let create now rng primary () =
+  let cache = Dns_resolver_cache.empty 100000 in
+  let cache =
+    List.fold_left (fun cache (name, rr) ->
+        Dns_resolver_cache.maybe_insert
+          Dns_enum.A name now Dns_resolver_entry.Additional
+          (Dns_resolver_entry.NoErr [ rr ]) cache)
+      cache Dns_resolver_root.a_records
+  in
+  let cache =
+    Dns_resolver_cache.maybe_insert
+      Dns_enum.NS Dns_name.root now Dns_resolver_entry.Additional
+      (Dns_resolver_entry.NoErr Dns_resolver_root.ns_records) cache
+  in
+  { rng ; cache ; primary ; transit = QM.empty ; queried = QM.empty }
+
+let header id = { Dns_packet.id ; query = true ; operation = Dns_enum.Query ;
+                  authoritative = false ; truncation = false ; recursion_desired = false ;
+                  recursion_available = false ; authentic_data = false ;
+                  checking_disabled = false ; rcode = Dns_enum.NoError }
+
+let build_query ?id ?(recursion_desired = false) t ts proto q retry edns ip =
+  let id = match id with Some id -> id | None -> Randomconv.int16 t.rng in
+  let header =
+    let hdr = header id in
+    { hdr with Dns_packet.recursion_desired }
+  in
+  let packet = header, `Query { Dns_packet.question = [q] ; answer = [] ; authority = [] ; additional = [] } in
+  let el = (ts, retry, proto, edns, ip, 53, q, id) in
+  let k = (q.Dns_packet.q_type, q.Dns_packet.q_name) in
+  let transit =
+    if QM.mem k t.transit then
+      Logs.warn (fun m -> m "overwriting transit of %a (%a)" Dns_name.pp (snd k) Dns_enum.pp_rr_typ (fst k)) ;
+    QM.add k el t.transit
+  in
+  transit, packet
+
+let maybe_query ?recursion_desired t ts retry out ip typ name (proto, edns, orig_s, orig_p, orig_q, orig_id) =
+  let k = (typ, name) in
+  let await = (ts, succ out, proto, edns, orig_s, orig_p, orig_q, orig_id) in
+  if QM.mem k t.queried then
+    let t = { t with queried = QM.add k (await :: QM.find k t.queried) t.queried } in
+    `Nothing, t
+  else
+    let edns = Some []
+    and proto = `Udp
+    in
+    let quest = { Dns_packet.q_type = typ ; q_name = name } in
+    (* TODO: is `Udp good here? *)
+    let transit, packet = build_query ?recursion_desired t ts proto quest retry edns ip in
+    let t = { t with transit ; queried = QM.add k [await] t.queried } in
+    let packet, _ = Dns_packet.encode ?edns proto packet in
+    `Query (packet, ip), t
+
+let was_in_transit t typ name id sender =
+  let key = (typ, name) in
+  match QM.find key t with
+  | exception Not_found ->
+    s := { !s with drops = succ !s.drops } ;
+    Logs.warn (fun m -> m "key %a (%a) not present in set (likely retransmitted)"
+                  Dns_name.pp name Dns_enum.pp_rr_typ typ) ;
+    None, t
+  | (_ts, _retry, _proto, edns, o_sender, _o_port, _o_q, o_id) ->
+    if Ipaddr.V4.compare sender o_sender = 0 && id = o_id then
+      Some edns, QM.remove key t
+    else
+      (Logs.warn (fun m -> m "unsolicited reply for %a (%a) (id %d vs o_id %d, sender %a vs o_sender %a)"
+                    Dns_name.pp name Dns_enum.pp_rr_typ typ
+                    id o_id Ipaddr.V4.pp_hum sender Ipaddr.V4.pp_hum o_sender) ;
+       None, t)
+
+let find_queries t k =
+  match QM.find k t with
+  | exception Not_found ->
+    Logs.warn (fun m -> m "couldn't find entry %a (%a) in map"
+                  Dns_name.pp (snd k) Dns_enum.pp_rr_typ (fst k)) ;
+    s := { !s with drops = succ !s.drops } ;
+    t, []
+  | vals ->
+    QM.remove k t, vals
+
+let stats t =
+  Logs.info (fun m -> m "stats: %a@.%a@.%d cached resource records (capacity: %d)"
+                pp_stats !s
+                Dns_resolver_cache.pp_stats (Dns_resolver_cache.stats ())
+                (Dns_resolver_cache.items t.cache) (Dns_resolver_cache.capacity t.cache)) ;
+  let names = QM.fold (fun (t, nam) _e acc ->
+      (Printf.sprintf "%s (%s)" (Dns_name.to_string nam) (Dns_enum.rr_typ_to_string t)):: acc)
+      t.transit []
+  in
+  Logs.info (fun m -> m "%d queries in transit %s" (QM.cardinal t.transit) (String.concat "; " names)) ;
+  let qs = QM.fold (fun (t, nam) e acc ->
+      (Printf.sprintf "[%d] %s (%s)" (List.length e) (Dns_name.to_string nam) (Dns_enum.rr_typ_to_string t)):: acc)
+      t.queried []
+  in
+  Logs.info (fun m -> m "%d queries %s" (QM.cardinal t.queried) (String.concat "; " qs))
+
+let handle_query t its out ?(retry = 0) proto edns from port ts q qid =
+  if Int64.sub ts its > Int64.shift_left retry_interval 2 then begin
+    Logs.warn (fun m -> m "dropping q %a from %a:%d (timed out)"
+                  Dns_packet.pp_question q Ipaddr.V4.pp_hum from port) ;
+    s := { !s with drop_timeout = succ !s.drop_timeout } ;
+    `Nothing, t
+  end else
+    let r, cache = Dns_resolver_cache.handle_query t.cache ~rng:t.rng (* primary *) ts q qid in
+    let t = { t with cache } in
+    match r with
+    | `Query _ when out >= 30 ->
+      Logs.warn (fun m -> m "dropping q %a from %a:%d (already sent 30 packets)"
+                    Dns_packet.pp_question q Ipaddr.V4.pp_hum from port) ;
+      s := { !s with drop_send = succ !s.drop_send } ;
+      (* TODO reply with error! *)
+      `Nothing, t
+    | `Query (nam, typ, ip) ->
+      Logs.debug (fun m -> m "have to query %a (%s) using ip %a"
+                     Dns_name.pp nam (Dns_enum.rr_typ_to_string typ) Ipaddr.V4.pp_hum ip) ;
+      maybe_query t ts retry out ip typ nam (proto, edns, from, port, q, qid)
+    | `Answer a ->
+      let max_out = if !s.max_out < out then out else !s.max_out in
+      let time = Int64.sub ts its in
+      let max_time = if !s.max_time < time then time else !s.max_time in
+      s := { !s with
+             answers = succ !s.answers ;
+             max_out ; total_out = !s.total_out + out ;
+             max_time ; total_time = Int64.add !s.total_time time ;
+           } ;
+      Logs.debug (fun m -> m "answering %a (%a) after %a %d out packets"
+                     Dns_name.pp q.Dns_packet.q_name
+                     Dns_enum.pp_rr_typ q.Dns_packet.q_type
+                     Duration.pp time out) ;
+      let max_size, edns = match edns with
+        | None -> None, None
+        | Some x -> Dns_packet.payload_size x, Some []
+      in
+      let cs, _ = Dns_packet.encode ?max_size ?edns proto a in
+      `Answer cs, t
+    | `Nothing -> `Nothing, t
+
+let scrub_it t proto edns ts q header query =
+  match Dns_resolver_utils.scrub q header query, edns with
+  | Ok xs, _ ->
+    let cache =
+      List.fold_left
+        (fun t (ty, n, r, e) -> Dns_resolver_cache.maybe_insert ty n ts r e t)
+        t xs
+    in
+    if header.Dns_packet.truncation && proto = `Udp then
+      (Logs.warn (fun m -> m "NS truncated reply, using TCP now") ;
+       `Upgrade_to_tcp cache)
+    else
+      `Cache cache
+  | Error Dns_enum.FormErr, Some _ ->
+    Logs.warn (fun m -> m "NS sent FormErr, retrying without edns!") ;
+    `Query_without_edns
+  | Error e, _ ->
+    Logs.warn (fun m -> m "NS didn't like us %a" Dns_enum.pp_rcode e) ;
+    `Try_another_ns
+
+let guard p err = if p then Ok () else Error (err ())
+
+let handle_primary t now ts proto sender header v tsig_off buf =
+  (* makes only sense to ask primary for query=true since we'll never issue questions from primary *)
+  let handle_inner name =
+    if not header.Dns_packet.query then
+      `No
+    else
+      match Dns_server.Primary.handle_frame t ts sender proto name (header, v) with
+      | Ok (t, answer, _) ->
+        begin match answer with
+          | None ->
+            Logs.err (fun m -> m "answer from authoritative is none, shouldn't happen") ;
+            assert false
+          | Some (header, v') ->
+            (* delegation if authoritative is not set! *)
+            if header.Dns_packet.authoritative then begin
+              s := { !s with authoritative = succ !s.authoritative } ;
+              let max_size, edns = match Dns_packet.find_edns v with
+                | None -> None, None
+                | Some edns -> Dns_packet.payload_size edns, Some []
+              in
+              let out = Dns_packet.encode ?max_size ?edns proto (header, v') in
+              `Reply (t, out)
+            end else begin
+              s := { !s with delegation = succ !s.delegation } ;
+              `Delegation v'
+            end
+        end
+      | Error rcode ->
+        Logs.debug (fun m -> m "authoritative returned %a" Dns_enum.pp_rcode rcode) ;
+        `No
+  in
+  match Dns_server.handle_tsig (Dns_server.Primary.server t) now (header, v) tsig_off buf with
+  | Error data -> `Reply (t, data)
+  | Ok None ->
+    begin match handle_inner None with
+      | `No -> `No
+      | `Delegation t -> `Delegation t
+      | `Reply (t, (buf, _)) -> `Reply (t, buf)
+    end
+  | Ok (Some (name, tsig, mac, key)) ->
+    match handle_inner (Some name) with
+    | `Delegation a -> `Delegation a
+    | `No -> `No
+    | `Reply (t, (buf, max_size)) ->
+      match Dns_server.((Primary.server t).tsig_sign) ~max_size ~mac name tsig ~key buf with
+      | None ->
+        Logs.warn (fun m -> m "couldn't use %a to tsig sign, using unsigned reply" Dns_name.pp name) ;
+        `Reply (t, buf)
+      | Some (buf, _) -> `Reply (t, buf)
+
+let supported = [ Dns_enum.A ; Dns_enum.NS ; Dns_enum.CNAME ;
+                  Dns_enum.SOA ; Dns_enum.PTR ; Dns_enum.MX ;
+                  Dns_enum.TXT ; Dns_enum.AAAA ; Dns_enum.SRV ;
+                  Dns_enum.ANY ]
+
+let handle_awaiting_queries ?retry t ts q =
+  let queried, values = find_queries t.queried (q.Dns_packet.q_type, q.Dns_packet.q_name) in
+  let t = { t with queried } in
+  List.fold_left (fun (t, out_a, out_q) (old_ts, out, proto, edns, from, port, q, qid) ->
+      Logs.debug (fun m -> m "now querying %a" Dns_packet.pp_question q) ;
+      match handle_query ?retry t old_ts out proto edns from port ts q qid with
+      | `Nothing, t -> t, out_a, out_q
+      | `Query (pkt, dst), t -> t, out_a, (`Udp, dst, pkt) :: out_q
+      | `Answer pkt, t -> t, (proto, from, port, pkt) :: out_a, out_q)
+    (t, [], []) values
+
+let resolve t ts proto sender sport header v =
+  let id = header.Dns_packet.id
+  and error rcode =
+    s := { !s with errors = succ !s.errors } ;
+    let header = { header with Dns_packet.query = not header.Dns_packet.query } in
+    match Dns_packet.error header v rcode with
+    | None -> None
+    | Some (cs, _) -> Some cs
+  in
+  match v with
+  | `Query query ->
+    let q = match query.Dns_packet.question with | [x] -> Some x | _ -> None in
+    Logs.info (fun m -> m "resolving %a %a" Dns_packet.pp_header header
+                  Fmt.(option ~none:(unit "none") Dns_packet.pp_question) q) ;
+    begin match query.Dns_packet.question with
+      | [ q ] ->
+        if header.Dns_packet.query then begin
+          guard (header.Dns_packet.recursion_desired)
+            (fun () ->
+               Logs.err (fun m -> m "recursion not desired") ;
+               error Dns_enum.FormErr) >>= fun () ->
+          guard (List.mem q.Dns_packet.q_type supported)
+            (fun () ->
+               Logs.err (fun m -> m "unsupported query type %s"
+                            (Dns_enum.rr_typ_to_string q.Dns_packet.q_type)) ;
+               error Dns_enum.NotImp) >>= fun () ->
+          s := { !s with questions = succ !s.questions } ;
+          let edns = Dns_packet.find_edns v in
+          (* ask the cache *)
+          begin match handle_query t ts 0 proto edns sender sport ts q id with
+            | `Answer pkt, t -> Ok (t, [ (proto, sender, sport, pkt) ], [])
+            | `Nothing, t -> Ok (t, [], [])
+            | `Query (packet, dst), t -> Ok (t, [], [ `Udp, dst, packet ])
+          end
+        end else (* is not a query, but a response *) begin
+          let r =
+            if sport <> 53 then begin
+              Logs.err (fun m -> m "source port is not 53, but %d" sport) ;
+              (t, [], [])
+            end else begin
+              (* (a) first check whether frame was in transit! *)
+              let r, transit = was_in_transit t.transit q.Dns_packet.q_type q.Dns_packet.q_name id sender in
+              let t = { t with transit } in
+              match r with
+              | None -> (t, [], [])
+              | Some edns ->
+                s := { !s with responses = succ !s.responses } ;
+                (* (b) now we scrub and either *)
+                match scrub_it t.cache proto edns ts q header query with
+                | `Query_without_edns ->
+                  s := { !s with retry_edns = succ !s.retry_edns } ;
+                  let transit, packet = build_query t ts proto q 1 None sender in
+                  let cs, _ = Dns_packet.encode `Udp packet in
+                  ({ t with transit }, [], [ `Udp, sender, cs ])
+                | `Upgrade_to_tcp cache ->
+                  s := { !s with tcp_upgrade = succ !s.tcp_upgrade } ;
+                  (* RFC 2181 Sec 9: correct would be to drop entire frame, and retry with tcp *)
+                  (* but we're happy to retrieve the partial information, it may be useful *)
+                  let t = { t with cache } in
+                  (* this may provoke the very same question again -
+                     but since tcp is first, that should trigger the TCP connection,
+                     which is then reused... ok, we may send the same query twice
+                     with different ids *)
+                  let t, out_a, out_q = handle_awaiting_queries t ts q in
+                  let transit, packet = build_query t ts `Tcp q 1 None sender in
+                  let cs, _ = Dns_packet.encode `Tcp packet in
+                  ({ t with transit }, out_a, (`Tcp, sender, cs) :: out_q)
+                | `Try_another_ns ->
+                  (* is this the right behaviour? by luck we'll use another path *)
+                  handle_awaiting_queries t ts q
+                | `Cache cache ->
+                  let t = { t with cache } in
+                  handle_awaiting_queries t ts q
+            end
+          in
+          Ok r
+        end (* [ q ] && query or not *)
+      | question ->
+        Logs.warn (fun m -> m "got %d questions %a"
+                      (List.length question)
+                      Fmt.(list ~sep:(unit ";@ ") Dns_packet.pp_question) question) ;
+        Error (error Dns_enum.FormErr)
+    end (* `Query query *)
+  | v ->
+    Logs.err (fun m -> m "ignoring %a" Dns_packet.pp (header, v)) ;
+    Error (error Dns_enum.FormErr)
+
+let handle_delegation t ts proto sender sport header v v' =
+  Logs.debug (fun m -> m "handling delegation %a (for %a)"
+                 Dns_packet.pp_v v' Dns_packet.pp_v v) ;
+  let error rcode =
+    s := { !s with errors = succ !s.errors } ;
+    let header = { header with Dns_packet.query = not header.Dns_packet.query } in
+    match Dns_packet.error header v rcode with
+    | None -> t, [], []
+    | Some (cs, _) -> t, [ (proto, sender, sport, cs) ], []
+  in
+  match v with
+  | `Query q ->
+    begin match q.Dns_packet.question with
+      | [ q ] ->
+        begin match Dns_resolver_cache.answer t.cache ts q header.Dns_packet.id with
+          | `Query (name, cache) ->
+            (* parse v', which should contain an a record
+               ask that for the very same query! *)
+            let t = { t with cache } in
+            let ip =
+              match
+                List.fold_left (fun acc rr -> match rr.Dns_packet.rdata with
+                    | Dns_packet.A ip -> ip :: acc
+                    | _ -> acc) []
+                  (match v' with `Query v -> v.Dns_packet.additional | _ -> [])
+              with
+              | [] -> invalid_arg "bad delegation"
+              | [ ip ] -> ip
+              | ips ->
+                List.nth ips (Randomconv.int ~bound:(List.length ips) t.rng)
+            in
+            let edns = Dns_packet.find_edns v in
+            Logs.debug (fun m -> m "found ip %a, maybe querying for %a (%a)"
+                           Ipaddr.V4.pp_hum ip Dns_enum.pp_rr_typ q.Dns_packet.q_type Dns_name.pp name) ;
+            begin match maybe_query ~recursion_desired:true t ts 0 0 ip q.Dns_packet.q_type name (proto, edns, sender, sport, q, header.Dns_packet.id) with
+              | `Nothing, t ->
+                Logs.warn (fun m -> m "maybe_query for %a at %a returned nothing"
+                              Dns_name.pp name Ipaddr.V4.pp_hum ip) ;
+                t, [], []
+              | `Query (cs, ip), t ->
+                t, [], [ (`Udp, ip, cs) ]
+            end
+          | `Packet (pkt, cache) ->
+            let max_size, edns = match Dns_packet.find_edns v with
+              | None -> None, None
+              | Some edns -> Dns_packet.payload_size edns, Some []
+            in
+            let pkt, _ = Dns_packet.encode ?max_size ?edns proto pkt in
+            { t with cache }, [ (proto, sender, sport, pkt) ], []
+            (* send it out! we've a cache hit here! *)
+        end
+      | question ->
+        Logs.warn (fun m -> m "got %d questions %a"
+                      (List.length question)
+                      Fmt.(list ~sep:(unit ";@ ") Dns_packet.pp_question) question) ;
+        error Dns_enum.FormErr
+    end (* `Query query *)
+  | v ->
+    Logs.err (fun m -> m "ignoring %a" Dns_packet.pp (header, v)) ;
+    error Dns_enum.FormErr
+
+let handle_error proto sender sport buf =
+  match Dns_packet.decode_header buf with
+  | Error e ->
+    Logs.err (fun m -> m "couldn't parse header %a:@.%a"
+                 Dns_packet.pp_err e Cstruct.hexdump_pp buf) ;
+    []
+  | Ok header ->
+    let empty =
+      `Query { Dns_packet.question = [] ; answer = [] ;
+               authority = [] ; additional = [] }
+    and header = { header with Dns_packet.query = not header.Dns_packet.query }
+    in
+    match Dns_packet.error header empty Dns_enum.FormErr with
+    | None -> []
+    | Some (cs, _) -> [ (proto, sender, sport, cs) ]
+
+let handle t now ts proto sender sport buf =
+  match Dns_packet.decode buf with
+  | Error e ->
+    Logs.err (fun m -> m "parse error %a for@.%a"
+                 Dns_packet.pp_err e Cstruct.hexdump_pp buf) ;
+    s := { !s with errors = succ !s.errors } ;
+    t, handle_error proto sender sport buf, []
+  | Ok ((header, v), tsig_off) ->
+    Logs.info (fun m -> m "reacting to %a: %a" Dns_packet.pp_header header
+                  Dns_packet.pp_v v) ;
+    match handle_primary t.primary now ts proto sender header v tsig_off buf with
+    | `Reply (primary, pkt) ->
+      { t with primary }, [ (proto, sender, sport, pkt) ], []
+    | `Delegation v' ->
+      handle_delegation t ts proto sender sport header v v'
+    | `No ->
+      match resolve t ts proto sender sport header v with
+      | Ok a -> a
+      | Error (Some e) -> t, [ (proto, sender, sport, e) ], []
+      | Error None -> t, [], []
+
+let query_root t now proto =
+  let q_name = Dns_name.root
+  and q_type = Dns_enum.NS
+  in
+  match Dns_resolver_cache.find_ns t.cache t.rng now Dns_name.DomSet.empty q_name with
+  | `HaveIP ip, cache ->
+    let q = { Dns_packet.q_name ; q_type }
+    and id = Randomconv.int16 t.rng
+    in
+    let packet = header id, `Query { Dns_packet.question = [q] ; answer = [] ; authority = [] ; additional = [] } in
+    let edns = Some [] in
+    let el = (now, 0, proto, edns, ip, 53, q, id) in
+    let t = { t with transit = QM.add (q_type, q_name) el t.transit ; cache } in
+    let cs, _ = Dns_packet.encode ?edns proto packet in
+    t, (proto, ip, cs)
+  | _ -> assert false
+
+let max_retries = 5
+
+let err_retries t q_type q_name =
+  let t, reqs = find_queries t (q_type, q_name) in
+  t, List.map (fun (_, _, proto, _, ip, port, q, qid) ->
+      Logs.debug (fun m -> m "now erroring to %a" Dns_packet.pp_question q) ;
+      let q = `Query { Dns_packet.question = [ q ] ; answer = [] ; authority = [] ; additional = [] } in
+      let header =
+        let h = header qid in
+        { h with Dns_packet.query = false }
+      in
+      match Dns_packet.error header q Dns_enum.ServFail with
+      | None -> assert false
+      | Some (pkt, _) -> (proto, ip, port, pkt))
+    reqs
+
+let try_other_timer t ts =
+  let transit, rem =
+    QM.partition
+      (fun _ (c, _, _, _, _, _, _, _) -> Int64.sub ts c < retry_interval)
+      t.transit
+  in
+  let t = { t with transit } in
+  if QM.cardinal transit > 0 || QM.cardinal rem > 0 then
+    Logs.debug (fun m -> m "try_other timer wheel -- keeping %d, running over %d"
+                   (QM.cardinal transit) (QM.cardinal rem)) ;
+  QM.fold (fun (q_type, q_name) (_, retry, _, _, qs, _, _, _) (t, out_a, out_q) ->
+      let retry = succ retry in
+      if retry < max_retries then begin
+        s := { !s with retransmits = succ !s.retransmits } ;
+        let q = { Dns_packet.q_name ; q_type } in
+        let t, outa, outq = handle_awaiting_queries ~retry t ts q in
+        (t, outa @ out_a, outq @ out_q)
+      end else begin
+        Logs.info (fun m -> m "retry limit exceeded for %a (%a) at %a!"
+                      Dns_name.pp q_name Dns_enum.pp_rr_typ q_type
+                      Ipaddr.V4.pp_hum qs) ;
+        let queried, out_as = err_retries t.queried q_type q_name in
+        ({ t with queried }, out_as @ out_a, out_q)
+      end)
+    rem (t, [], [])
+
+let _retry_timer t ts =
+  if QM.cardinal t.transit > 0 then
+    Logs.debug (fun m -> m "retry timer with %d entries" (QM.cardinal t.transit)) ;
+  List.fold_left (fun (t, out_a, out_q) ((q_type, q_name), (c, retry, proto, edns, qs, _port, _query, id)) ->
+      if Int64.sub ts c < retry_interval then
+        (Logs.debug (fun m -> m "ignoring retransmit %a (%a) for now %a"
+                        Dns_name.pp q_name Dns_enum.pp_rr_typ q_type
+                        Duration.pp (Int64.sub ts c) ) ;
+         (t, out_a, out_q))
+      else
+        let retry = succ retry in
+        if retry < max_retries then begin
+          s := { !s with retransmits = succ !s.retransmits } ;
+          Logs.info (fun m -> m "retransmit %a %a (%d of %d) to %a"
+                        Dns_name.pp q_name Dns_enum.pp_rr_typ q_type
+                        retry max_retries Ipaddr.V4.pp_hum qs) ;
+          let transit, packet = build_query ~id t ts proto { Dns_packet.q_type ; q_name } retry edns qs in
+          let cs, _ = Dns_packet.encode ?edns proto packet in
+          { t with transit }, out_a, (`Udp, qs, cs) :: out_q
+        end else begin
+          Logs.info (fun m -> m "retry limit exceeded for %a (%a) at %a!"
+                        Dns_name.pp q_name Dns_enum.pp_rr_typ q_type
+                        Ipaddr.V4.pp_hum qs) ;
+          (* answer all outstanding requestors! *)
+          let transit = QM.remove (q_type, q_name) t.transit in
+          let t = { t with transit } in
+          let queried, out_as = err_retries t.queried q_type q_name in
+          ({ t with queried }, out_as @ out_a, out_q)
+        end)
+    (t, [], []) (QM.bindings t.transit)
+
+let timer = try_other_timer

--- a/resolver/dns_resolver.mli
+++ b/resolver/dns_resolver.mli
@@ -1,0 +1,18 @@
+(* (c) 2018 Hannes Mehnert, all rights reserved *)
+
+type t
+
+val create : int64 -> (int -> Cstruct.t) -> Dns_server.Primary.s -> unit -> t
+
+val handle : t -> Ptime.t -> int64 -> Dns_packet.proto -> Ipaddr.V4.t -> int -> Cstruct.t ->
+  t * (Dns_packet.proto * Ipaddr.V4.t * int * Cstruct.t) list
+    * (Dns_packet.proto * Ipaddr.V4.t * Cstruct.t) list
+
+val query_root : t -> int64 -> Dns_packet.proto ->
+  t * (Dns_packet.proto * Ipaddr.V4.t * Cstruct.t)
+
+val timer : t -> int64 ->
+  t * (Dns_packet.proto * Ipaddr.V4.t * int * Cstruct.t) list
+    * (Dns_packet.proto * Ipaddr.V4.t * Cstruct.t) list
+
+val stats : t -> unit

--- a/resolver/dns_resolver_cache.ml
+++ b/resolver/dns_resolver_cache.ml
@@ -1,4 +1,4 @@
-(* (c) 2017 Hannes Mehnert, all rights reserved *)
+(* (c) 2017, 2018 Hannes Mehnert, all rights reserved *)
 
 open Dns_resolver_entry
 
@@ -24,6 +24,29 @@ end
 module LRU = Lru.F.Make(Dns_name)(V)
 
 type t = LRU.t
+
+type stats = {
+  hit : int ;
+  miss : int ;
+  drop : int ;
+  insert : int ;
+}
+
+let s = ref { hit = 0 ; miss = 0 ; drop = 0 ; insert = 0 }
+
+let pp_stats pf s =
+  Fmt.pf pf "cache: %d hits %d misses %d drops %d inserts" s.hit s.miss s.drop s.insert
+
+let stats () = !s
+
+(* this could be improved:
+   lookup : t -> Dns_name.t -> Dns_enum.rr_typ -> int64 ->
+            (Dns_map.V, [ `NoErr | `NoDom | `ServFail | `Timeout ]) result
+
+   need to massage a bit more Dns_map (by providing some more type parameters)
+
+   or ask someone who knows more about GADT to help me fixing that data
+   structure properly. *)
 
 let empty = LRU.empty
 
@@ -62,25 +85,38 @@ let cached t ts typ nam =
   match LRU.find nam t with
   | None ->
     Logs.debug (fun m -> m "found nothing %a" Dns_name.pp nam) ;
+    s := { !s with miss = succ !s.miss } ;
     Error `Cache_miss
   | Some (V.All (created, _, res), t) ->
-    Logs.debug (fun m -> m "found all %a (%a) %a" Dns_name.pp nam Dns_enum.pp_rr_typ typ pp_res res) ;
+    Logs.debug (fun m -> m "found all %a (%a) %a" Dns_name.pp nam
+                   Dns_enum.pp_rr_typ typ pp_res res) ;
     begin match update_res created ts res with
-      | None -> Error `Cache_drop
-      | Some r -> Ok (r, t)
+      | None ->
+        s := { !s with drop = succ !s.drop } ;
+        Error `Cache_drop
+      | Some r ->
+        s := { !s with hit = succ !s.hit } ;
+        Ok (r, t)
     end
   | Some (V.Entries tm, t) ->
     match Dns_enum.RRMap.find typ tm with
     | exception Not_found ->
-      Logs.debug (fun m -> m "found entries for %a, but no matching rr typ (%a)" Dns_name.pp nam Dns_enum.pp_rr_typ typ) ;
+      Logs.debug (fun m -> m "found entries for %a, but no matching rr typ (%a): %a"
+                     Dns_name.pp nam Dns_enum.pp_rr_typ typ
+                     Fmt.(list ~sep:(unit ", ") Dns_enum.pp_rr_typ)
+                     (fst (List.split (Dns_enum.RRMap.bindings tm)))) ;
+      s := { !s with miss = succ !s.miss } ;
       Error `Cache_miss
     | (created, _, res) ->
-      Logs.debug (fun m -> m "found something %a (%a) %a" Dns_name.pp nam Dns_enum.pp_rr_typ typ pp_res res) ;
       match update_res created ts res with
       | None ->
-        Logs.debug (fun m -> m "didn't survive") ;
+        Logs.debug (fun m -> m "didn't survive, dropping %a %a since invalid"
+                       Dns_name.pp nam Dns_enum.pp_rr_typ typ) ;
+        s := { !s with drop = succ !s.drop } ;
         Error `Cache_drop
-      | Some r -> Ok (r, t)
+      | Some r ->
+        s := { !s with hit = succ !s.hit } ;
+        Ok (r, t)
 
 (* according to RFC1035, section 7.3, a TTL of a week is a good maximum value! *)
 (* XXX: we may want to define a minimum as well (5 minutes? 30 minutes?
@@ -104,7 +140,6 @@ and 1035 6.2:
    distributed from a zone.  This floor function should be done when the data is
    copied into a response.  This will allow future dynamic update protocols to
    change the SOA MINIMUM field without ambiguous semantics.
-
 *)
 let week = Int32.of_int Duration.(to_sec (of_day 7))
 let smooth_rr rr =
@@ -121,174 +156,234 @@ let smooth_ttl = function
   | ServFail rr -> ServFail (smooth_rr rr)
 
 let maybe_insert typ nam ts rank res t =
-  let entry tm =
-    let full = (ts, rank, smooth_ttl res) in
-    match typ, res with
-    | Dns_enum.CNAME, _ -> V.All full
-    | _, NoDom _ -> V.All full
-    | _, _ -> V.Entries (Dns_enum.RRMap.add typ full tm)
-  in
-  match LRU.find ~promote:false nam t with
-  | None -> LRU.add nam (entry Dns_enum.RRMap.empty) t
-  | Some (V.All (ts', rank', res'), t) ->
-    begin match update_res ts' ts res' with
-      | None -> LRU.add nam (entry Dns_enum.RRMap.empty) t
-      | Some _ ->
-        match compare_rank rank rank' with
-        | `Bigger -> t
-        | `Equal | `Smaller -> LRU.add nam (entry Dns_enum.RRMap.empty) t
-    end
-  | Some (V.Entries tm, t) ->
-    match Dns_enum.RRMap.find typ tm with
-    | exception Not_found -> LRU.add nam (entry tm) t
-    | (ts', rank', res') ->
-      match update_res ts' ts res' with
-      | None -> LRU.add nam (entry tm) t
-      | Some _ ->
-        match compare_rank rank rank' with
-        | `Bigger -> t
-        | `Equal | `Smaller -> LRU.add nam (entry tm) t
+  match res with
+  | NoErr [] ->
+    Logs.warn (fun m -> m "won't add an empty rr for %a (%a)!"
+                  Dns_name.pp nam Dns_enum.pp_rr_typ typ) ;
+    t
+  | _ ->
+    let entry tm =
+      let full = (ts, rank, smooth_ttl res) in
+      match typ, res with
+      | Dns_enum.CNAME, _ -> V.All full
+      | _, NoDom _ -> V.All full
+      | _, _ -> V.Entries (Dns_enum.RRMap.add typ full tm)
+    in
+    match LRU.find ~promote:false nam t with
+    | None -> LRU.add nam (entry Dns_enum.RRMap.empty) t
+    | Some (V.All (ts', rank', res'), t) ->
+      begin match update_res ts' ts res' with
+        | None ->
+          s := { !s with insert = succ !s.insert } ;
+          LRU.add nam (entry Dns_enum.RRMap.empty) t
+        | Some _ ->
+          match compare_rank rank' rank with
+          | `Bigger -> t
+          | `Equal | `Smaller ->
+            s := { !s with insert = succ !s.insert } ;
+            LRU.add nam (entry Dns_enum.RRMap.empty) t
+      end
+    | Some (V.Entries tm, t) ->
+      match Dns_enum.RRMap.find typ tm with
+      | exception Not_found ->
+        s := { !s with insert = succ !s.insert } ;
+        LRU.add nam (entry tm) t
+      | (ts', rank', res') ->
+        match update_res ts' ts res' with
+        | None ->
+          s := { !s with insert = succ !s.insert } ;
+          LRU.add nam (entry tm) t
+        | Some _ ->
+          match compare_rank rank' rank with
+          | `Bigger -> t
+          | `Equal | `Smaller ->
+            s := { !s with insert = succ !s.insert } ;
+            LRU.add nam (entry tm) t
 
 let resolve_ns t ts name =
   match cached t ts Dns_enum.A name with
-  | Error _ -> Ok (`NeedA name, t)
+  | Error _ -> `NeedA name, t
   | Ok (NoErr answer, t) ->
-    (match
-       List.fold_left (fun acc rr -> match rr.Dns_packet.rdata with
-           | Dns_packet.A ip -> ip :: acc
-           | _ -> acc)
-         [] answer
-     with
-     | [] -> Ok (`NeedA name, t)
-     | ips -> Ok (`HaveIP ips, t))
-  | _ -> Error ()
+    begin match
+        List.fold_left (fun acc rr ->
+            match rr.Dns_packet.rdata, acc with
+            | Dns_packet.A ip, `Ip ips -> `Ip (ip :: ips)
+            | Dns_packet.A ip, _ -> `Ip [ ip ]
+            | _, `Ip ips -> `Ip ips
+            | Dns_packet.CNAME name, `No -> `Cname name
+            | rdata, x ->
+              Logs.warn (fun m -> m "resolve_ns: ignoring %a (looked A %a)"
+                           Dns_packet.pp_rdata rdata Dns_name.pp name) ;
+              x)
+          `No answer
+      with
+      | `No -> `NeedA name, t
+      | `Ip ips -> `HaveIPS ips, t
+      | `Cname cname ->
+        Logs.warn
+          (fun m -> m "resolve_ns: asked for A record of NS %a, got cname %a"
+              Dns_name.pp name Dns_name.pp cname) ;
+        `NeedCname cname, t
+    end
+  | Ok (NoDom rr, t) ->
+    Logs.warn (fun m -> m "resolve_ns: NoDom, cache lookup for %a is %a"
+                  Dns_name.pp name Dns_packet.pp_rr rr) ;
+    `NoDom, t
+  | Ok (r, t) ->
+    Logs.warn (fun m -> m "resolve_ns: No, cache lookup for %a is %a"
+                  Dns_name.pp name pp_res r) ;
+    `No, t
 
-let root_servers =
-  List.map Ipaddr.V4.of_string_exn [ "141.1.1.1" ; "8.8.8.8" ]
-(*    (* a.root-servers.net *) "198.41.0.4" (* , 2001:503:ba3e::2:30 VeriSign, Inc. *) ;
-    (* b.root-servers.net *) "192.228.79.201" (* , 2001:500:84::b University of Southern California (ISI) *) ;
-    (* c.root-servers.net *) "192.33.4.12" (* , 2001:500:2::c Cogent Communications *) ;
-    (* d.root-servers.net *) "199.7.91.13" (* , 2001:500:2d::d University of Maryland *) ;
-    (* e.root-servers.net *) "192.203.230.10" (* , 2001:500:a8::e NASA (Ames Research Center) *) ;
-    (* f.root-servers.net *) "192.5.5.241" (* , 2001:500:2f::f Internet Systems Consortium, Inc. *) ;
-    (* g.root-servers.net *) "192.112.36.4" (* , 2001:500:12::d0d US Department of Defense (NIC) *) ;
-    (* h.root-servers.net *) "198.97.190.53" (* , 2001:500:1::53 US Army (Research Lab) *) ;
-    (* i.root-servers.net *) "192.36.148.17" (* , 2001:7fe::53 Netnod *) ;
-    (* j.root-servers.net *) "192.58.128.30" (* , 2001:503:c27::2:30 VeriSign, Inc. *) ;
-    (* k.root-servers.net *) "193.0.14.129" (* , 2001:7fd::1 RIPE NCC *) ;
-    (* l.root-servers.net *) "199.7.83.42" (* , 2001:500:9f::42 ICANN *) ;
-      (* m.root-servers.net *) "202.12.27.33" (* , 2001:dc3::35 WIDE Project *)
-      ] *)
+let find_ns t rng ts stash name =
+  let pick = function
+    | [] -> assert false
+    | [ x ] -> x
+    | xs -> List.nth xs (Randomconv.int ~bound:(List.length xs) rng)
+  in
+  match cached t ts Dns_enum.NS name with
+  | Error _ -> `NeedNS, t
+  | Ok (NoErr [], t) -> `No, t
+  | Ok (NoErr xs, t) ->
+    (* TODO test case -- we can't pick right now, unfortunately
+       the following setup is there in the wild:
+       berliner-zeitung.de NS 1.ns.berlinonline.de, 2.ns.berlinonline.de, x.ns.berlinonline.de
+       berlinonline.de NS 1.ns.berlinonline.net, 2.ns.berlinonline.net, dns-berlinonline-de.unbelievable-machine.net
+       berlinonline.net NS 2.ns.berlinonline.de, x.ns.berlinonline.de, 1.ns.berlinonline.de.
+       --> all delivered without glue *)
+    begin match
+        List.fold_left (fun acc rr ->
+            match acc, rr.Dns_packet.rdata with
+            | `Name ns, Dns_packet.NS n -> `Name (Dns_name.DomSet.add n ns)
+            | _, Dns_packet.NS n -> `Name (Dns_name.DomSet.singleton n)
+            | `Nothing, Dns_packet.CNAME name -> `Cname name (* foo.com CNAME bar.com case *)
+            | acc, x ->
+              Logs.err (fun m -> m "find_ns: looked for NS %a, but got %a"
+                           Dns_name.pp name Dns_packet.pp_rdata x) ;
+              acc) `Nothing xs
+      with
+      | `Cname name -> `Cname name, t
+      | `Nothing -> `No, t
+      | `Name ns ->
+        let actual = Dns_name.DomSet.diff ns stash in
+        if Dns_name.DomSet.is_empty actual then begin
+          Logs.debug (fun m -> m "find_ns: couldn't take any name from %a (stash: %a)"
+                         Fmt.(list ~sep:(unit ",@ ") Dns_name.pp) (Dns_name.DomSet.elements ns)
+                         Fmt.(list ~sep:(unit ",@ ") Dns_name.pp) (Dns_name.DomSet.elements stash)) ;
+          `Loop, t
+        end else
+          let nsname = pick (Dns_name.DomSet.elements actual) in
+          (* tricky conditional:
+              foo.com NS ns1.foo.com ; ns1.foo.com CNAME ns1.bar.com (well, may not happen ;)
+              foo.com NS ns1.foo.com -> NeedGlue foo.com *)
+          match resolve_ns t ts nsname with
+          | `NeedA aname, t when Dns_name.sub ~subdomain:aname ~domain:name -> `NeedGlue name, t
+          | `NeedCname cname, t -> `NeedA cname, t
+          | `HaveIPS ips, t -> `HaveIP (pick ips), t
+          | `NeedA aname, t -> `NeedA aname, t
+          | `No, t -> `No, t
+          | `NoDom, t -> `NoDom, t
+    end
+  | Ok (_, t) -> `No, t
 
-let pick xs =
-  match xs with
-  | [] -> `No
-  | xs ->
-  let r = Random.int (List.length xs) in
-  List.nth xs r
+let resolve t ~rng ts name typ =
+  (* the top-to-bottom approach, for TYP a.b.c, lookup:
+     NS, . -> A1
+     NS, c -> A2
+     NS, b.c -> A3
+     NS. a.b.c -> A4
+     TYP, a.b.c -> A5
 
-let find_ns t ?(overlay = fun _ -> None) ts name =
-  let open Rresult.R.Infix in
-  if Dns_name.equal name Dns_name.root then `HaveIP root_servers, t
-  else match overlay name with
-    | Some ip -> `HaveIP [ip], t
-    | None ->
-      match cached t ts Dns_enum.NS name with
-    | Error _ -> `NeedNS, t
-    | Ok (NoErr answers, t) ->
-      (match
-         (* correctness? this fails if there's a single non-NS answer for this
-            query -- if resolve_ns fails -- can we ever insert such a RR? *)
-         List.fold_left (fun acc rr ->
-             acc >>= fun (rs, t) ->
-             match rr.Dns_packet.rdata with
-             | Dns_packet.CNAME name -> Ok (`Cname name :: rs, t)
-             | Dns_packet.NS name -> resolve_ns t ts name >>= fun (x, t) -> Ok (x :: rs, t)
-             | _ -> Error ())
-           (Ok ([], t))
-           answers
-       with
-       | Error () -> `No, t
-       (* this _used_ to use the RNG *)
-       | Ok ([ `Cname name ], t) -> `Cname name, t
-       | Ok ([], t) -> `No, t
-       | Ok (r::rs, t) ->
-         pick (List.filter (function `HaveIP _ -> true | _ -> false) (r::rs)), t)
-    | Ok (_, t) -> `No, t
+     where A{1-4} are all domain names, where we try to find A records
 
-let resolve t ?overlay ts name typ =
-  (* the top-to-bottom approach *)
+     now, we have the issue of glue records: NS c (A2) will return names x.c
+     and y.c, but also address records for them (otherwise there's no way to
+     find out their addresses without knowing their addresses)
+
+     A2 may as well contain a.c, b.c, and c.d - if delivered without glue, c.d
+     is the only option to proceed (well, or ServFail or asking someone else for
+     NS c) *)
   (* goal is to find the query to send out.
-      we're applying qname minimisation on the way down
+     we're applying qname minimisation on the way down
 
      it's a bit complicated, OTOH we're doing qname minimisation, but also may
-     have to jump to other names (of NS or CNAME) - which is slightly intricate
-*)
-  let rec go t stash typ cur rest ips =
-    Logs.debug (fun m -> m "resolve called with stash %a typ %a cur %a rest %a ips %a"
+     have to jump to other names (of NS or CNAME) - which is slightly intricate *)
+  let root =
+    let roots = snd (List.split Dns_resolver_root.root_servers) in
+    List.nth roots (Randomconv.int ~bound:(List.length roots) rng)
+  in
+  let rec go t stash typ cur rest ip =
+    Logs.debug (fun m -> m "resolve entry: stash %a typ %a cur %a rest %a ip %a"
                    Fmt.(list ~sep:(unit ", ") Dns_name.pp) (N.elements stash)
                    Dns_enum.pp_rr_typ typ Dns_name.pp cur
                    Dns_name.pp (Dns_name.of_strings_exn ~hostname:false rest)
-                   Fmt.(list ~sep:(unit ", ") Ipaddr.V4.pp_hum) ips) ;
-    match find_ns t ?overlay ts cur with
-    | `HaveIP ips, t ->
-      Logs.debug (fun m -> m "resolve: have ips %a" Fmt.(list ~sep:(unit ", ") Ipaddr.V4.pp_hum) ips) ;
+                   Ipaddr.V4.pp_hum ip) ;
+    match find_ns t rng ts stash cur with
+    | `NeedNS, t when Dns_name.equal cur Dns_name.root ->
+      (* we don't have any root servers *)
+      Ok (cur, Dns_enum.NS, root, t)
+    | `HaveIP ip, t ->
+      Logs.debug (fun m -> m "resolve: have ip %a" Ipaddr.V4.pp_hum ip) ;
       begin match rest with
-        | [] -> Ok (cur, typ, ips, t)
-        | hd::tl -> go t stash typ (Dns_name.prepend_exn cur hd) tl ips
+        | [] -> Ok (cur, typ, ip, t)
+        | hd::tl -> go t stash typ (Dns_name.prepend_exn cur hd) tl ip
       end
     | `NeedNS, t ->
       Logs.debug (fun m -> m "resolve: needns") ;
-      Ok (cur, Dns_enum.NS, ips, t)
+      Ok (cur, Dns_enum.NS, ip, t)
     | `Cname name, t ->
+      (* NS name -> CNAME foo, only use foo is rest is empty *)
       Logs.debug (fun m -> m "resolve: cname %a" Dns_name.pp name) ;
       begin match rest with
         | [] ->
           let rest = List.rev (Dns_name.to_strings name) in
-          go t (N.add name stash) typ Dns_name.root rest []
-        | hd::tl -> go t stash typ (Dns_name.prepend_exn ~hostname:false cur hd) tl ips
+          go t (N.add name stash) typ Dns_name.root rest root
+        | hd::tl ->
+          go t stash typ (Dns_name.prepend_exn cur hd) tl ip
       end
-    | `No, t ->
-      Logs.debug (fun m -> m "resolve: no!") ;
-      (* in the NXDomain case, this is wrong (but we can't do much about it) *)
-      (* this opens the door to amplification attacks :/ *)
-      let name = Dns_name.of_strings_exn ~hostname:false (rest @ Dns_name.to_strings cur) in
-      Ok (name, typ, ips, t)
-(*      begin match rest with
-        | [] -> Ok (cur, typ, ips, t)
-        | hd::tl -> go t stash typ (Dns_name.prepend_exn ~hostname:false cur hd) tl ips
-        end*)
+    | `NoDom, _ ->
+      (* this is wrong for NS which NoDom for too much (even if its a ENT) *)
+      Logs.debug (fun m -> m "resolve: nodom to %a!" Dns_name.pp cur) ;
+      Error "can't resolve"
+    | `No, _ ->
+      Logs.debug (fun m -> m "resolve: no to %a!" Dns_name.pp cur) ;
+      (* we tried to locate the NS for cur, but failed to find it *)
+      (* it was ServFail/NoData in our cache.  how can we proceed? *)
+      (* - ask the very same question to ips (NS / cur) - but we need to stop at some point *)
+      (* - if rest = [], we just ask for cur+typ the ips --- this is common, e.g.
+            ns1.foo.com NS @(foo.com authoritative)? - NoData, ns1.foo.com A @(foo.com authoritative) yay *)
+      (* - if rest != [], (i.e. detectportal.firefox.com.edgesuite.net ->
+               edgesuite.net -> NoData *)
+      (* - give up!? *)
+      (* this opens the door to amplification attacks :/ -- i.e. asking for
+         a.b.c.d.e.f results in 6 requests (for f, e.f, d.e.f, c.d.e.f, b.c.d.e.f, a.b.c.d.e.f)  *)
+      begin match rest with
+        | [] -> Ok (cur, typ, ip, t)
+        | hd::tl -> go t stash typ (Dns_name.prepend_exn cur hd) tl ip
+      end
+    | `NeedGlue name, t ->
+      Logs.debug (fun m -> m "resolve: needGlue %a" Dns_name.pp name) ;
+      Ok (name, Dns_enum.NS, ip, t)
+    | `Loop, _ -> Error "resolve: cycle detected in find_ns"
     | `NeedA name, t ->
       Logs.debug (fun m -> m "resolve: needA %a" Dns_name.pp name) ;
+      (* TODO: unclear whether this conditional is needed *)
       if N.mem name stash then begin
-        (* XXX: this needs more work regarding glue records -- done in resolver.ml
-           it happens when NS foo.com? -> NS 50 ns1.foo.com, NS 50 ns2.foo.com,
-           ns1.foo.com A 1 1.2.3.4, ns2.foo.com A 1 1.2.3.5 *)
-        (*if Dns_name.sub ~subdomain:name ~domain:cur then
-            let par = Dns_name.parent cur in
-            match find_ns t ts par with
-            | `HaveIP ips, t -> Ok (cur, Dns_enum.NS, ips, t)
-            | `NeedNS, t -> Ok (par, Dns_enum.NS, root_servers, t)
-            | `No, t -> Ok (par, Dns_enum.NS, root_servers, t)
-            | `NeedA nam, t -> go t (N.add name stash) Dns_enum.A Dns_name.root (List.rev (Dns_name.to_strings nam)) root_servers
-          else begin
-            Logs.err (fun m -> m "cycle detected in nameserver search for %a: %a (%a)"
-                         Dns_name.pp cur Dns_name.pp name
-                         (Fmt.list ~sep:(Fmt.unit ";") Dns_name.pp) (N.elements stash)) ;
-            Error "cycle detected"
-          end *)
-        Error "cycle detected"
+        Error "resolve: cycle detected during NeedA"
       end else
         let n = List.rev (Dns_name.to_strings name) in
-        go t (N.add name stash) Dns_enum.A Dns_name.root n []
+        go t (N.add name stash) Dns_enum.A Dns_name.root n root
   in
-  go t (N.singleton name) typ Dns_name.root (List.rev (Dns_name.to_strings name)) []
+  go t (N.singleton name) typ Dns_name.root (List.rev (Dns_name.to_strings name)) root
 
 let follow_cname t ts typ name answer =
   let rec follow t names acc curr =
     match
       match curr with
-      | [x] -> (match x.Dns_packet.rdata with Dns_packet.CNAME n -> Some n | _ -> None)
+      | [ x ] ->
+        begin match x.Dns_packet.rdata with
+          | Dns_packet.CNAME n -> Some n
+          | _ -> None
+        end
       | _ -> None
     with
     | None ->
@@ -296,7 +391,7 @@ let follow_cname t ts typ name answer =
                      Fmt.(list ~sep:(unit ", ") Dns_name.pp) (N.elements names)) ;
       `NoError (acc, t)
     | Some n ->
-      Logs.debug (fun m -> m "looking in %d for (names %a) %a (%a)"
+      Logs.debug (fun m -> m "looking in %d items for (names %a) %a (%a)"
                      (LRU.items t)
                      Fmt.(list ~sep:(unit ", ") Dns_name.pp) (N.elements names)
                      Dns_name.pp n Dns_enum.pp_rr_typ typ) ;
@@ -325,15 +420,13 @@ let follow_cname t ts typ name answer =
   in
   follow t (N.singleton name) answer answer
 
-let names = Dns_packet.rr_names
-
 let additionals t ts rrs =
   (* TODO: also AAAA *)
   N.fold (fun nam (acc, t) ->
       match cached t ts Dns_enum.A nam with
       | Ok (NoErr answers, t) -> answers @ acc, t
       | _ -> acc, t)
-    (names rrs)
+    (Dns_packet.rr_names rrs)
     ([], t)
 
 let answer t ts q id =
@@ -347,7 +440,7 @@ let answer t ts q id =
     and additional, t = if add then additionals t ts answer else [], t
     and question = [ q ]
     in
-    (header, { Dns_packet.question ; answer ; authority ; additional }), t
+    (header, `Query { Dns_packet.question ; answer ; authority ; additional }), t
   in
   match cached t ts q.Dns_packet.q_type q.Dns_packet.q_name with
   | Error _ -> `Query (q.Dns_packet.q_name, t)
@@ -368,17 +461,35 @@ let answer t ts q id =
       | `NoData ((answer, soa), t) -> `Packet (packet t true Dns_enum.NoError answer [soa])
       | `ServFail (soa, t) -> `Packet (packet t true Dns_enum.ServFail [] [soa])
 
-let handle_query t ?overlay sender sport ts q qid =
+let handle_query t ~rng ts q qid =
   match answer t ts q qid with
-  | `Packet ((header, packet), t) ->
-    let buf = Cstruct.create 512 in
-    let l = Dns_packet.encode_query buf header packet in
-    `Answer (Cstruct.sub buf 0 l, (sender, sport)), t
+  | `Packet (pkt, t) -> `Answer pkt, t
   | `Query (name, t) ->
-    match resolve t ?overlay ts name q.Dns_packet.q_type with
-    | Ok (name, typ, ips, t) ->
-      (* this _used_ to use the RNG *)
-      (match ips with
-       | [] -> `Nothing, t
-       | ip::_ -> `Query (name, typ, ip), t)
-    | Error _ -> `Nothing, t
+    let r =
+      match q.Dns_packet.q_type with
+      | Dns_enum.SRV when Dns_name.is_service name ->
+        let a = Dns_name.to_array name in
+        Ok (Dns_name.of_array Array.(sub a 0 (length a - 2)), Dns_enum.NS)
+      | Dns_enum.SRV ->
+        Logs.err (fun m -> m "requested SRV record %a, but not a service name"
+                     Dns_name.pp name) ;
+        Error ()
+      | x -> Ok (name, x)
+    in
+    match r with
+    | Error () -> `Nothing, t
+    | Ok (qname, typ) ->
+      match resolve t ~rng ts qname typ with
+      | Error e ->
+        Logs.err (fun m -> m "resolve returned error %s" e) ;
+        `Nothing, t
+      | Ok (name', typ, ip, t) ->
+        let name, typ =
+          match Dns_name.equal name' qname, q.Dns_packet.q_type with
+          | true, Dns_enum.SRV -> name, Dns_enum.SRV
+          | _ -> name', typ
+        in
+        Logs.debug (fun m -> m "resolve returned %a %a, %a" Dns_name.pp name
+                       Dns_enum.pp_rr_typ typ
+                       Ipaddr.V4.pp_hum ip) ;
+        `Query (name, typ, ip), t

--- a/resolver/dns_resolver_root.ml
+++ b/resolver/dns_resolver_root.ml
@@ -1,0 +1,76 @@
+(* (c) 2018 Hannes Mehnert, all rights reserved *)
+
+let root_servers =
+  List.map (fun (n, ip) -> Dns_name.of_string_exn n, Ipaddr.V4.of_string_exn ip)
+    [
+      "a.root-servers.net", "198.41.0.4" ; (* , 2001:503:ba3e::2:30 VeriSign, Inc. *)
+      "b.root-servers.net", "199.9.14.201" ; (* , 2001:500:200::b University of Southern California (ISI) *)
+      "c.root-servers.net", "192.33.4.12" ; (* , 2001:500:2::c Cogent Communications *)
+      "d.root-servers.net", "199.7.91.13" ; (* , 2001:500:2d::d University of Maryland *)
+      "e.root-servers.net", "192.203.230.10" ; (* , 2001:500:a8::e NASA (Ames Research Center) *)
+      "f.root-servers.net", "192.5.5.241" ; (* , 2001:500:2f::f Internet Systems Consortium, Inc. *)
+      "g.root-servers.net", "192.112.36.4" ; (* , 2001:500:12::d0d US Department of Defense (NIC) *)
+      "h.root-servers.net", "198.97.190.53" ; (* , 2001:500:1::53 US Army (Research Lab) *)
+      "i.root-servers.net", "192.36.148.17" ; (* , 2001:7fe::53 Netnod *)
+      "j.root-servers.net", "192.58.128.30" ; (* , 2001:503:c27::2:30 VeriSign, Inc. *)
+      "k.root-servers.net", "193.0.14.129" ; (* , 2001:7fd::1 RIPE NCC *)
+      "l.root-servers.net", "199.7.83.42" ; (* , 2001:500:9f::42 ICANN *)
+      "m.root-servers.net", "202.12.27.33" (* , 2001:dc3::35 WIDE Project *)
+  ]
+
+let a_ttl = 3600000l
+let ns_ttl = 518400l
+
+let ns_records =
+  List.map (fun (name, _) ->
+      let ttl = ns_ttl
+      and rdata = Dns_packet.NS name
+      in
+      { Dns_packet.name = Dns_name.root ; ttl ; rdata })
+    root_servers
+
+let a_records =
+  List.map (fun (name, ip) ->
+      let ttl = a_ttl
+      and rdata = Dns_packet.A ip
+      in
+      name, { Dns_packet.name ; ttl ; rdata })
+    root_servers
+
+let reserved_zones =
+  let n = Dns_name.of_string_exn in
+  (* RFC 6761, avoid them to get out of here + multicast DNS 6762 *)
+  let zones =
+    Dns_name.DomSet.(add (n "local") (* multicast dns, RFC 6762 *)
+                       (add (n "test") (add (n "invalid") (* RFC 6761 *)
+                                          (add (n "localhost") (* RFC 6761, draft let-localhost-be-localhost *)
+                                             empty))))
+  in
+  let rec gen acc pos up = function
+    | n when succ n = up -> List.rev acc
+    | n ->
+      let net = string_of_int n ^ pos in
+      gen (net :: acc) pos up (succ n)
+  in
+  let nets = [ (* RFC 6761 and RFC 6890 *)
+    "0" (* 0.0.0.0/8 *) ;
+    "10" (* 10.0.0.0/8 *) ;
+    "127" (* 127.0.0.0/8 *) ;
+    "254.169" (* "169.254.0.0/16" *) ;
+    "0.0.192" (* "192.0.0.0/24" *) ;
+    "2.0.192" (* "192.0.2.0/24" *) ;
+    "168.192" (* "192.168.0.0/16" *) ;
+    "18.198" ; "19.198" (* "198.18.0.0/15" *) ;
+    "100.51.198" (* "198.51.100.0/24" *) ;
+    "113.0.203" (* "203.0.113.0/24" *) ;
+  ] @ gen [] ".100" 128 64 (* "100.64.0.0/10" ; *)
+    @ gen [] ".172" 32 16 (* "172.16.0.0/12" ; *)
+    @ gen [] "" 256 240 (* "240.0.0.0/4" *)
+  in
+  List.fold_left (fun m net ->
+      let name = net ^ ".in-addr.arpa" in
+      Dns_name.DomSet.add (n name) m)
+    zones nets
+(* XXX V6 reserved nets (also RFC6890) *)
+
+

--- a/resolver/dns_resolver_root.mli
+++ b/resolver/dns_resolver_root.mli
@@ -1,0 +1,9 @@
+(* (c) 2018 Hannes Mehnert, all rights reserved *)
+
+val root_servers : (Dns_name.t * Ipaddr.V4.t) list
+
+val ns_records : Dns_packet.rr list
+
+val a_records : (Dns_name.t * Dns_packet.rr) list
+
+val reserved_zones : Dns_name.DomSet.t

--- a/resolver/dns_resolver_utils.mli
+++ b/resolver/dns_resolver_utils.mli
@@ -1,7 +1,7 @@
-(* (c) 2017 Hannes Mehnert, all rights reserved *)
+(* (c) 2017, 2018 Hannes Mehnert, all rights reserved *)
 
 val scrub : Dns_packet.question -> Dns_packet.header -> Dns_packet.query ->
   ((Dns_enum.rr_typ * Dns_name.t * Dns_resolver_entry.rank * Dns_resolver_entry.res) list,
-   [> `Msg of string ]) result
+   Dns_enum.rcode) result
 
 val invalid_soa : Dns_name.t -> Dns_packet.rr

--- a/resolver/udns_resolver.mllib
+++ b/resolver/udns_resolver.mllib
@@ -1,3 +1,5 @@
+Dns_resolver_root
 Dns_resolver_entry
 Dns_resolver_utils
 Dns_resolver_cache
+Dns_resolver

--- a/server/dns_trie.ml
+++ b/server/dns_trie.ml
@@ -1,4 +1,4 @@
-(* (c) 2017 Hannes Mehnert, all rights reserved *)
+(* (c) 2017, 2018 Hannes Mehnert, all rights reserved *)
 
 module O = struct
   type t = string
@@ -34,14 +34,18 @@ let ent name map =
   let ttl, soa = Dns_map.get Dns_map.K.Soa map in
   `EmptyNonTerminal (name, ttl, soa)
 let to_ns name map =
-  let ttl, ns, _glue = Dns_map.get Dns_map.K.Ns map in
+  let ttl, ns =
+    match Dns_map.find Dns_map.K.Ns map with
+    | None -> 0l, Dns_name.DomSet.empty
+    | Some (ttl, ns) -> ttl, ns
+  in
   (name, ttl, ns)
 
 let lookup_res name zone ty m =
   match zone with
   | None -> Error `NotAuthoritative
-  | Some (`Delegation (name, (ttl, ns, map))) ->
-    Error (`Delegation (name, (ttl, ns, Dns_map.glue map)))
+  | Some (`Delegation (name, (ttl, ns))) ->
+    Error (`Delegation (name, (ttl, ns)))
   | Some (`Soa (z, zmap)) ->
     guard (not (Dns_map.is_empty m)) (ent z zmap) >>= fun () ->
     match ty with
@@ -55,11 +59,17 @@ let lookup_res name zone ty m =
       in
       Ok (Dns_map.V (Dns_map.K.Any, (rrs, names)), to_ns z zmap)
     | _ -> match Dns_map.lookup_rr ty m with
-      | None -> begin match Dns_map.findv Dns_map.K.Cname m with
-          | None -> Error (ent z zmap)
-          | Some cname -> Ok (cname, to_ns z zmap)
-        end
       | Some v -> Ok (v, to_ns z zmap)
+      | None -> match Dns_map.findv Dns_map.K.Cname m with
+        | None when Dns_map.cardinal m = 1 && Dns_map.(mem K.Soa m) ->
+          (* this is primary a hack for localhost, which must be NXDomain,
+             but there's a SOA for localhost (to handle it authoritatively) *)
+          (* TODO should we check that the label-node map is empty?
+                well, if we have a proper authoritative zone, there'll be a NS *)
+          let ttl, soa = Dns_map.get Dns_map.K.Soa zmap in
+          Error (`NotFound (z, ttl, soa))
+        | None -> Error (ent z zmap)
+        | Some cname -> Ok (cname, to_ns z zmap)
 
 let lookup_aux name t =
   let k = Dns_name.to_array name in
@@ -78,8 +88,8 @@ let lookup_aux name t =
       else match M.find (Array.get k idx) sub with
         | exception Not_found ->
           begin match zone with
-            | Some (`Delegation (name, (ttl, ns, map))) ->
-              Error (`Delegation (name, (ttl, ns, Dns_map.glue map)))
+            | Some (`Delegation (name, (ttl, ns))) ->
+              Error (`Delegation (name, (ttl, ns)))
             | None -> Error `NotAuthoritative
             | Some (`Soa (name, map)) ->
               let ttl, soa = Dns_map.get Dns_map.K.Soa map in
@@ -89,34 +99,9 @@ let lookup_aux name t =
   in
   go 0 None t
 
-let lookup_a name ty t =
+let lookup name ty t =
   lookup_aux name t >>= fun (zone, _sub, map) ->
   lookup_res name zone ty map
-
-let lookup name typ t =
-  lookup_aux name t >>= fun (zone, _sub, m) ->
-  match zone with
-  | None -> Error `NotAuthoritative
-  | Some (`Delegation (name, (ttl, ns, map))) ->
-    Error (`Delegation (name, (ttl, ns, Dns_map.glue map)))
-  | Some (`Soa (name, zmap)) ->
-    guard (not (Dns_map.is_empty m)) (ent name zmap) >>= fun () ->
-    match typ with
-    | Dns_enum.ANY ->
-      let bindings = Dns_map.bindings m in
-      let rrs = List.(flatten (map (Dns_map.to_rr name) bindings))
-      and names =
-        List.fold_left
-          (fun acc v -> Dns_name.DomSet.union acc (Dns_map.names v))
-          Dns_name.DomSet.empty bindings
-      in
-      Ok (Dns_map.V (Dns_map.K.Any, (rrs, names)))
-    | _ -> match Dns_map.lookup_rr typ m with
-      | None -> begin match Dns_map.findv Dns_map.K.Cname m with
-          | None -> Error (ent name zmap)
-          | Some cname -> Ok cname
-        end
-      | Some v -> Ok v
 
 let lookup_ignore name ty t =
   match lookup_aux name t with
@@ -146,37 +131,50 @@ let collect_map name rrmap =
   (* collecting rr out of rrmap + name, no SOA! *)
   Dns_map.fold (fun v acc ->
       match v with
-      | Dns_map.V (Dns_map.K.Soa, _) -> acc (* this is only used for AXFR, and we need to treat SOA specially (first and last item) *)
+      | Dns_map.V (Dns_map.K.Soa, _) -> acc
       | v -> Dns_map.to_rr name v @ acc)
     rrmap []
 
 let walk name sub map =
   let rec go name sub map =
     let entries = collect_map name map in
-    (* we stop at zone boundaries -- ns entries without soa are suspicious *)
-    let cont = not Dns_map.(mem K.Ns map && not (mem K.Soa map)) in
-    if cont then
-      List.fold_left
-        (fun acc (pre, N (sub, map)) ->
-           acc @ go (Dns_name.prepend_exn ~hostname:false name pre) sub map)
-        entries (M.bindings sub)
-    else
-      entries
+    List.fold_left
+      (fun acc (pre, N (sub, map)) ->
+         acc @ go (Dns_name.prepend_exn ~hostname:false name pre) sub map)
+      entries (M.bindings sub)
   in
   go name sub map
 
 let collect_entries name sub map =
-    let ttl, soa = Dns_map.get Dns_map.K.Soa map in
-    { Dns_packet.name ; ttl ; rdata = Dns_packet.SOA soa }, walk name sub map
+  let ttlsoa =
+    match Dns_map.find Dns_map.K.Soa map with
+    | Some v -> Some v
+    | None when Dns_name.(equal root name) ->
+      Some (0l, { Dns_packet.nameserver = Dns_name.root ;
+                  hostmaster = Dns_name.root ;
+                  serial = 0l ; refresh = 0l ; retry = 0l ;
+                  expiry = 0l ; minimum = 0l })
+    | None -> None
+  in
+  match ttlsoa with
+  | None -> Error `NotAuthoritative
+  | Some (ttl, soa) ->
+    let entries = walk name sub map in
+    Ok ({ Dns_packet.name ; ttl ; rdata = Dns_packet.SOA soa }, entries)
 
 let entries name t =
-  lookup_aux name t >>= fun (zone, sub, map) ->
-  match zone with
-  | None -> Error `NotAuthoritative
-  | Some (`Delegation (name, (ttl, ns, map))) ->
-    Error (`Delegation (name, (ttl, ns, Dns_map.glue map)))
-  | Some (`Soa (name', _)) when Dns_name.equal name name' -> Ok (collect_entries name sub map)
-  | Some (`Soa (_, _)) -> Error `NotAuthoritative
+  if Dns_name.(equal root name) then
+    let N (sub, map) = t in
+    collect_entries name sub map
+  else
+    lookup_aux name t >>= fun (zone, sub, map) ->
+    match zone with
+    | None -> Error `NotAuthoritative
+    | Some (`Delegation (name, (ttl, ns))) ->
+      Error (`Delegation (name, (ttl, ns)))
+    | Some (`Soa (name', _)) when Dns_name.equal name name' ->
+      collect_entries name sub map
+    | Some (`Soa (_, _)) -> Error `NotAuthoritative
 
 type err = [ `Missing_soa of Dns_name.t
            | `Cname_other of Dns_name.t
@@ -184,7 +182,6 @@ type err = [ `Missing_soa of Dns_name.t
            | `Bad_ttl of Dns_name.t * Dns_map.v
            | `Empty of Dns_name.t * Dns_enum.rr_typ
            | `Missing_address of Dns_name.t
-           | `Missing_ns of Dns_name.t
            | `Soa_not_ns of Dns_name.t ]
 
 (* TODO: check for no cname loops? and dangling cname!? *)
@@ -211,52 +208,51 @@ let check trie =
            not (Dns_map.mem Dns_map.K.Cname map)) (`Cname_other name) >>= fun () ->
     Dns_map.fold (fun v r ->
         r >>= fun () ->
-        match state', v with
-        | _, Dns_map.V (Dns_map.K.Dnskey, _) -> Ok ()
-        | _, Dns_map.V (Dns_map.K.Any, _) -> Error (`Any_not_allowed name)
-        | `None, _ -> Error (`Missing_soa name)
-        | `Soa _, Dns_map.V (Dns_map.K.Cname, (ttl, _)) ->
+        match v with
+        | Dns_map.V (Dns_map.K.Dnskey, _) -> Ok ()
+        | Dns_map.V (Dns_map.K.Any, _) -> Error (`Any_not_allowed name)
+        | Dns_map.V (Dns_map.K.Ns, (ttl, names)) ->
+          if ttl < 0l then Error (`Bad_ttl (name, v))
+          else if Dns_name.DomSet.cardinal names = 0 then
+            Error (`Empty (name, Dns_enum.NS))
+          else
+            let domain = match state' with `None -> name | `Soa zone -> zone in
+            Dns_name.DomSet.fold (fun name r ->
+                r >>= fun () ->
+                if Dns_name.sub ~subdomain:name ~domain then
+                  guard (has_address name) (`Missing_address name)
+                else
+                  Ok ()) names (Ok ())
+        | Dns_map.V (Dns_map.K.Cname, (ttl, _)) ->
           if ttl < 0l then Error (`Bad_ttl (name, v)) else Ok ()
-        | `Soa zone, Dns_map.V (Dns_map.K.Mx, (ttl, mxs)) ->
+        | Dns_map.V (Dns_map.K.Mx, (ttl, mxs)) ->
           if ttl < 0l then
             Error (`Bad_ttl (name, v))
           else begin match mxs with
             | [] -> Error (`Empty (name, Dns_enum.MX))
             | mxs ->
+              let domain = match state' with `None -> name | `Soa zone -> zone in
               List.fold_left (fun r (_, name) ->
                   r >>= fun () ->
-                  if Dns_name.sub ~subdomain:name ~domain:zone then
+                  if Dns_name.sub ~subdomain:name ~domain then
                     guard (has_address name) (`Missing_address name)
                   else
                     Ok ())
                 (Ok ()) mxs
           end
-        | `Soa _, Dns_map.V (Dns_map.K.Ns, (ttl, names, glue)) ->
-          if ttl < 0l then Error (`Bad_ttl (name, v))
-          else if Dns_name.DomSet.cardinal names = 0 then
-            Error (`Empty (name, Dns_enum.NS))
-          else
-            Dns_name.DomSet.fold (fun n r ->
-                r >>= fun () ->
-                match Dns_name.DomMap.find n glue with
-                | exception Not_found -> guard (has_address n) (`Missing_address n)
-                | ((_, _ :: _), _) -> Ok ()
-                | (_, (_, _ :: _)) -> Ok ()
-                | _ -> Error (`Missing_address n))
-              names (Ok ())
-        | `Soa _, Dns_map.V (Dns_map.K.Ptr, (ttl, name)) ->
+        | Dns_map.V (Dns_map.K.Ptr, (ttl, name)) ->
           if ttl < 0l then Error (`Bad_ttl (name, v)) else Ok ()
-        | `Soa _, Dns_map.V (Dns_map.K.Soa, (ttl, soa)) ->
+        | Dns_map.V (Dns_map.K.Soa, (ttl, soa)) ->
           if ttl < 0l then Error (`Bad_ttl (name, v))
           else begin match Dns_map.find Dns_map.K.Ns map with
-            | Some (_, names, _) ->
+            | Some (_, names) ->
               if Dns_name.DomSet.mem soa.Dns_packet.nameserver names then
                 Ok ()
               else
                 Error (`Soa_not_ns soa.Dns_packet.nameserver)
-            | None -> Error (`Missing_ns name)
+            | None -> Ok () (* we're happy to only have a soa, but nothing else -- useful for grounding zones! *)
           end
-        | `Soa _, Dns_map.V (Dns_map.K.Txt, (ttl, txts)) ->
+        | Dns_map.V (Dns_map.K.Txt, (ttl, txts)) ->
           if ttl < 0l then Error (`Bad_ttl (name, v))
           else begin match txts with
             | [] -> Error (`Empty (name, Dns_enum.TXT))
@@ -264,22 +260,22 @@ let check trie =
               if List.for_all (fun txt -> List.length txt > 0 && List.for_all (fun x -> String.length x > 0) txt) xs then
                 Ok ()
               else Error (`Empty (name, Dns_enum.TXT)) end
-        | `Soa _, Dns_map.V (Dns_map.K.A, (ttl, a)) ->
+        | Dns_map.V (Dns_map.K.A, (ttl, a)) ->
           if ttl < 0l then Error (`Bad_ttl (name, v))
           else begin match a with
             | [] -> Error (`Empty (name, Dns_enum.A))
             | _ -> Ok () end
-        | `Soa _, Dns_map.V (Dns_map.K.Aaaa, (ttl, aaaa)) ->
+        | Dns_map.V (Dns_map.K.Aaaa, (ttl, aaaa)) ->
           if ttl < 0l then Error (`Bad_ttl (name, v))
           else begin match aaaa with
             | [] -> Error (`Empty (name, Dns_enum.AAAA))
             | _ -> Ok () end
-        | `Soa _, Dns_map.V (Dns_map.K.Srv, (ttl, srvs)) ->
+        | Dns_map.V (Dns_map.K.Srv, (ttl, srvs)) ->
           if ttl < 0l then Error (`Bad_ttl (name, v))
           else begin match srvs with
             | [] -> Error (`Empty (name, Dns_enum.SRV))
             | _ -> Ok () end
-        | `Soa _, Dns_map.V (Dns_map.K.Caa, (ttl, caas)) ->
+        | Dns_map.V (Dns_map.K.Caa, (ttl, caas)) ->
           if ttl < 0l then Error (`Bad_ttl (name, v))
           else begin match caas with
             | [] -> Error (`Empty (name, Dns_enum.CAA))
@@ -365,14 +361,12 @@ let pp_err ppf = function
   | `Bad_ttl (name, v) -> Fmt.pf ppf "bad TTL for %a %a" Dns_name.pp name Dns_map.pp_v v
   | `Empty (name, typ) -> Fmt.pf ppf "%a empty %a" Dns_name.pp name Dns_enum.pp_rr_typ typ
   | `Missing_address name -> Fmt.pf ppf "missing address record for %a" Dns_name.pp name
-  | `Missing_ns name -> Fmt.pf ppf "missing NS entry in %a" Dns_name.pp name
   | `Soa_not_ns name -> Fmt.pf ppf "%a nameserver of SOA is not in nameserver set" Dns_name.pp name
 
 let pp_e ppf = function
-  | `Delegation (name, (ttl, ns, glue)) ->
-    Fmt.pf ppf "delegation %a to TTL %lu %a glue %a" Dns_name.pp name ttl
+  | `Delegation (name, (ttl, ns)) ->
+    Fmt.pf ppf "delegation %a to TTL %lu %a" Dns_name.pp name ttl
       Fmt.(list ~sep:(unit ",@,") Dns_name.pp) (Dns_name.DomSet.elements ns)
-      Dns_packet.pp_rrs glue
   | `EmptyNonTerminal (name, ttl, soa) ->
     Fmt.pf ppf "empty non terminal %a TTL %lu SOA %a" Dns_name.pp name ttl Dns_packet.pp_soa soa
   | `NotAuthoritative -> Fmt.string ppf "not authoritative"

--- a/src/dns_map.mli
+++ b/src/dns_map.mli
@@ -53,8 +53,7 @@ module K : sig
     | Any : (Dns_packet.rr list * Dns_name.DomSet.t) t
     | Cname : (int32 * Dns_name.t) t
     | Mx : (int32 * (int * Dns_name.t) list) t
-    | Ns : (int32 * Dns_name.DomSet.t *
-            ((int32 * Ipaddr.V4.t list) * (int32 * Ipaddr.V6.t list)) Dns_name.DomMap.t) t
+    | Ns : (int32 * Dns_name.DomSet.t) t
     | Ptr : (int32 * Dns_name.t) t
     | Soa : (int32 * Dns_packet.soa) t
     | Txt : (int32 * string list list) t


### PR DESCRIPTION
this includes various enhancements:
- `Ns` now does not contain any glue (was brittle enough, and didn't lead to desired results)
- EDNS is now supported and used
- upgrade to TCP is done whenever a truncated packet is received
- retry now calls out to `resolve` again, rather than retransmitting the very same udp frame to the same remote
- storing resource records without a SOA is now possible (use case is to delegate to an open recursive resolve for a specific zone (such as `.`))
- fix DNSKEY encoding (blit with src and dst exchanged)