### PR TITLE
fix compilation errors in unikernel examples

### DIFF
--- a/mirage/examples/primary/unikernel.ml
+++ b/mirage/examples/primary/unikernel.ml
@@ -25,7 +25,7 @@ module Main (R : RANDOM) (P : PCLOCK) (M : MCLOCK) (T : TIME) (S : STACKV4) = st
     let open Dns_trie in
     let open Dns_map in
     let t = insert (n "mirage") (V (K.Soa, (ttl, soa))) Dns_trie.empty in
-    let t = insert (n "mirage") (V (K.Ns, (ttl, s ns, Dns_name.DomMap.empty))) t in
+    let t = insert (n "mirage") (V (K.Ns, (ttl, s ns))) t in
     let t = insert (n "nuc.mirage") (V (K.A, (ttl, [ ip "10.0.0.1" ]))) t in
     let t = insert ns (V (K.A, (ttl, [ ip "10.0.0.2" ]))) t in
     let t = insert (n "charrua.mirage") (V (K.A, (ttl, [ ip "10.0.0.3" ]))) t in

--- a/mirage/examples/resolver/unikernel.ml
+++ b/mirage/examples/resolver/unikernel.ml
@@ -37,7 +37,7 @@ module Main (R : RANDOM) (P : PCLOCK) (M : MCLOCK) (T : TIME) (S : STACKV4) = st
         ~tsig_verify:Dns_tsig.verify ~tsig_sign:Dns_tsig.sign ~rng:R.generate
         trie
     in
-    let p = Dns_resolver.create ~root:true now R.generate server () in
+    let p = Dns_resolver.create now R.generate server () in
     D.resolver s pclock mclock p ;
     S.listen s
 end


### PR DESCRIPTION
With these minor adjustments, all of the unikernel examples compile
without errors.  Built against Mirage's "unix" target using OCaml
4.06.0.