### PR TITLE
revise client flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ The µDNS library is published under the 2 clause BSD license.
 ## Installation
 
 You first need to install [OCaml](https://ocaml.org) (at least 4.04.0) and
-[opam](https://opam.ocaml.org), the OCaml package manager (at least 1.2.2) on
+[opam](https://opam.ocaml.org), the OCaml package manager (at least 2.0.0) on
 your machine (you can use opam to install an up-to-date OCaml (`opam switch
-4.06.0`)).  You may want to follow the [mirage installation
+4.07.1`)).  You may want to follow the [mirage installation
 instructions](https://mirage.io/wiki/install) to get `mirage` installed on your
 computer.
 
@@ -85,4 +85,4 @@ examples at the [unikernel repository](https://github.com/roburio/unikernels).
 
 ## Documentation
 
-Is unfortunately only in the code at the moment.
+API documentation [is available online](https://roburio.github.io/udns/doc/).

--- a/app/odns.ml
+++ b/app/odns.ml
@@ -99,7 +99,7 @@ let do_txt nameserver domains _ =
 let do_any nameserver domains _ =
   for_all_domains nameserver ~domains Udns_map.Any
     (fun domain -> function
-       | Ok (rr_list, _domain_names) ->
+       | Ok rr_list ->
          List.iter (fun rr -> Logs.app (fun m -> m "%a" Udns_packet.pp_rr rr))
            rr_list
        | Error (`Msg msg) ->

--- a/client/udns_client.ml
+++ b/client/udns_client.ml
@@ -69,12 +69,7 @@ let parse_response (type requested)
           ) >>= fun relevant_map ->
       begin match (state.key : requested Udns_map.k) with
         | (Udns_map.Any : requested Udns_map.k) ->
-          Ok (((resp.answer:Udns_packet.rr list) ,
-               (((Udns_map.of_rrs resp.answer
-                  |> Domain_name.Map.bindings
-                  |> List.map fst
-                  |> Domain_name.Set.of_list)
-                ) : Domain_name.Set.t)):requested)
+          Ok ((resp.answer, Domain_name.Set.empty):requested)
         | _ ->
           begin match Udns_map.find state.key relevant_map with
             | Some response -> Ok response

--- a/client/udns_client.ml
+++ b/client/udns_client.ml
@@ -69,7 +69,7 @@ let parse_response (type requested)
           ) >>= fun relevant_map ->
       begin match (state.key : requested Udns_map.k) with
         | (Udns_map.Any : requested Udns_map.k) ->
-          Ok ((resp.answer, Domain_name.Set.empty):requested)
+          Ok (resp.answer:requested)
         | _ ->
           begin match Udns_map.find state.key relevant_map with
             | Some response -> Ok response

--- a/mirage/client/udns_mirage_client.mli
+++ b/mirage/client/udns_mirage_client.mli
@@ -4,7 +4,7 @@ module Make (S : Mirage_stack_lwt.V4) : sig
     with type flow = S.TCPV4.flow
      and type io_addr = Ipaddr.V4.t * int
      and type (+'a, +'b) io = ('a, 'b) Lwt_result.t
-     and type stack = S.tcpv4
+     and type stack = S.t
 
   include module type of Udns_client_flow.Make(Uflow)
 end

--- a/resolver/udns_resolver_utils.mli
+++ b/resolver/udns_resolver_utils.mli
@@ -1,6 +1,7 @@
 (* (c) 2017, 2018 Hannes Mehnert, all rights reserved *)
 
-val scrub : ?mode:[ `Recursive | `Stub ] -> Domain_name.t -> Udns_packet.question -> Udns_packet.header -> Udns_packet.query ->
+val scrub : ?mode:[ `Recursive | `Stub ] -> Domain_name.t ->
+  Udns_packet.question -> Udns_packet.header -> Udns_packet.query ->
   ((Udns_enum.rr_typ * Domain_name.t * Udns_resolver_entry.rank * Udns_resolver_entry.res) list,
    Udns_enum.rcode) result
 

--- a/src/udns_map.mli
+++ b/src/udns_map.mli
@@ -32,7 +32,7 @@ module SshfpSet : Set.S with type elt = Udns_packet.sshfp
 (** A set of SSH FP records. *)
 
 type _ k =
-  | Any : (Udns_packet.rr list * Domain_name.Set.t) k
+  | Any : Udns_packet.rr list k
   | Cname : (int32 * Domain_name.t) k
   | Mx : (int32 * MxSet.t) k
   | Ns : (int32 * Domain_name.Set.t) k

--- a/src/udns_trie.ml
+++ b/src/udns_trie.ml
@@ -54,13 +54,8 @@ let lookup_res name zone ty m =
     match ty with
     | Udns_enum.ANY ->
       let bindings = Udns_map.bindings m in
-      let rrs = List.(flatten (map (Udns_map.to_rr name) bindings))
-      and names =
-        List.fold_left
-          (fun acc v -> Domain_name.Set.union acc (Udns_map.names v))
-          Domain_name.Set.empty bindings
-      in
-      Ok (Udns_map.B (Udns_map.Any, (rrs, names)), to_ns z zmap)
+      let rrs = List.(flatten (map (Udns_map.to_rr name) bindings)) in
+      Ok (Udns_map.B (Udns_map.Any, rrs), to_ns z zmap)
     | _ -> match Udns_map.lookup_rr ty m with
       | Some v -> Ok (v, to_ns z zmap)
       | None -> match Udns_map.findb Udns_map.Cname m with

--- a/unix/client/ohostname.ml
+++ b/unix/client/ohostname.ml
@@ -1,6 +1,7 @@
 let () =
+  let t = Udns_client_unix.create () in
   let res =
-    Udns_client_unix.gethostbyname () (Domain_name.of_string_exn Sys.argv.(1)) in
+    Udns_client_unix.gethostbyname t (Domain_name.of_string_exn Sys.argv.(1)) in
   match res with
   | Ok addr -> Fmt.pr "%a\n" Ipaddr.V4.pp addr
   | Error (`Msg x) -> Fmt.epr "Failed to resolve: %s\n" x; exit 1

--- a/unix/client/udns_client_unix.mli
+++ b/unix/client/udns_client_unix.mli
@@ -6,7 +6,7 @@
 (** A flow module based on blocking I/O on top of the Unix socket API. *)
 module Uflow : Udns_client_flow.S
   with type flow = Unix.file_descr
-   and type io_addr = string * int
+   and type io_addr = Unix.inet_addr * int
    and type stack = unit
    and type (+'a,+'b) io = ('a,'b) result
 


### PR DESCRIPTION
now, instead of defining `stack` and `flow`, we also define a type `t`, and a `create : ?nameserver -> stack -> t`. The type `t` is used (instead of `stack`) in `gethostbyname`.

with these changes, https://github.com/mirage/ocaml-conduit/pull/290 brings a mirage-conduit that uses udns and this new API