### PR TITLE
read longer responses

### DIFF
--- a/client/udns_client_flow.mli
+++ b/client/udns_client_flow.mli
@@ -54,6 +54,8 @@ module type S = sig
 
   val map : ('ok,'err) io -> ('ok -> ('next,'err) io) -> ('next,'err) io
   (** a.k.a. [>>=] *)
+
+  val lift : ('ok, 'err) result -> ('ok,'err) io
 end
 
 module Make : functor (U : S) ->

--- a/lwt/client/udns_client_lwt.ml
+++ b/lwt/client/udns_client_lwt.ml
@@ -45,6 +45,7 @@ module Uflow : Udns_client_flow.S
 
   let map = Lwt_result.bind
   let resolve = Lwt_result.bind_result
+  let lift = Lwt_result.lift
 
   let connect ?nameserver:ns t =
     let (proto, (server, port)) = match ns with None -> nameserver t | Some x -> x in

--- a/mirage/client/udns_mirage_client.ml
+++ b/mirage/client/udns_mirage_client.ml
@@ -29,6 +29,7 @@ module Make (S : Mirage_stack_lwt.V4) = struct
 
     let map = Lwt_result.bind
     let resolve = Lwt_result.bind_result
+    let lift = Lwt_result.lift
 
     let connect ?nameserver:ns t =
       let _proto, addr = match ns with None -> nameserver t | Some x -> x in

--- a/unix/client/udns_client_unix.ml
+++ b/unix/client/udns_client_unix.ml
@@ -23,6 +23,7 @@ module Uflow : Udns_client_flow.S
 
   let map = Rresult.R.((>>=))
   let resolve = (Rresult.R.(>>=))
+  let lift v = v
 
   open Rresult
 


### PR DESCRIPTION
This still doesn't quite work, but couldn't find the issue:
```shell
udns $ ./_build/default/app/odns.exe any --ns 198.167.222.214 -vvv robur.io
...
odns.exe: [ERROR] Failed to lookup robur.io: err: Error parsing response: bad content robur.io
```

EDIT: This PR has some extra debug messages that should probably be removed before merging, but thought them useful while debugging.