### PR TITLE
fix dns-client-unix; replace some `cardinal` with `is_empty`

### DIFF
--- a/resolver/dns_resolver.ml
+++ b/resolver/dns_resolver.ml
@@ -499,7 +499,7 @@ let try_other_timer t ts =
       t.transit
   in
   let t = { t with transit } in
-  if QM.cardinal transit > 0 || QM.cardinal rem > 0 then
+  if not (QM.is_empty transit && QM.is_empty rem) then
     Logs.debug (fun m -> m "try_other timer wheel -- keeping %d, running over %d"
                    (QM.cardinal transit) (QM.cardinal rem)) ;
   QM.fold (fun (name, typ) (_, retry, _, _, _, qs, _, _, _) (t, out_a, out_q) ->
@@ -517,7 +517,7 @@ let try_other_timer t ts =
     rem (t, [], [])
 
 let _retry_timer t ts =
-  if QM.cardinal t.transit > 0 then
+  if not (QM.is_empty t.transit) then
     Logs.debug (fun m -> m "retry timer with %d entries" (QM.cardinal t.transit)) ;
   List.fold_left (fun (t, out_a, out_q) (key, (c, retry, proto, zone, edns, qs, _port, _query, id)) ->
       if Int64.sub ts c < retry_interval then

--- a/server/dns_trie.ml
+++ b/server/dns_trie.ml
@@ -263,7 +263,7 @@ let check trie =
           else Ok ()
         | B (Ns, (ttl, names)) ->
           if ttl < 0l then Error (`Bad_ttl (name, v))
-          else if Domain_name.Set.cardinal names = 0 then
+          else if Domain_name.Set.is_empty names then
             Error (`Empty (name, K Ns))
           else
             let domain = match state' with `None -> name | `Soa zone -> zone in

--- a/unix/client/dune
+++ b/unix/client/dune
@@ -2,7 +2,7 @@
   (name        dns_client_unix)
   (modules     dns_client_unix)
   (public_name dns-client-unix)
-  (libraries   domain-name ipaddr dns-client rresult)
+  (libraries   domain-name ipaddr dns-client rresult unix)
   (wrapped     false)
 )
 


### PR DESCRIPTION
This fixes a build error for `dns-client-unix`:
```
# File "_none_", line 1:
# Error: No implementations provided for the following modules:
#          Unix referenced from unix/client/dns_client_unix.cmxa(Dns_client_unix)
```

And replaces some instances of `cardinal t = 0` with `is_empty t` which imho is easier to read, and easier to reason about performance-wise.