### PR TITLE
adapt to domain-name phantom type API

### DIFF
--- a/mirage/server/udns_mirage_server.ml
+++ b/mirage/server/udns_mirage_server.ml
@@ -19,21 +19,23 @@ module Make (P : Mirage_clock_lwt.PCLOCK) (M : Mirage_clock_lwt.MCLOCK) (TIME : 
       tcp_out := Dns.IM.remove ip !tcp_out ;
       state := Udns_server.Primary.closed !state ip
     in
-    let send_notify (ip, data) =
+
+    let connect recv_task ip =
       let dport = 53 in
-      let connect ip =
-        Log.info (fun m -> m "creating connection to %a:%d" Ipaddr.V4.pp ip dport) ;
-        T.create_connection (S.tcpv4 stack) (ip, dport) >>= function
-        | Error e ->
-          Log.err (fun m -> m "error %a while establishing tcp connection to %a:%d"
-                      T.pp_error e Ipaddr.V4.pp ip port) ;
-          Lwt.return (Error ())
-        | Ok flow ->
-          tcp_out := Dns.IM.add ip flow !tcp_out;
-          Lwt.return (Ok flow)
-      in
+      Log.info (fun m -> m "creating connection to %a:%d" Ipaddr.V4.pp ip dport) ;
+      T.create_connection (S.tcpv4 stack) (ip, dport) >>= function
+      | Error e ->
+        Log.err (fun m -> m "error %a while establishing tcp connection to %a:%d"
+                    T.pp_error e Ipaddr.V4.pp ip port) ;
+        Lwt.return (Error ())
+      | Ok flow ->
+        Lwt.async (recv_task ip dport flow);
+        Lwt.return (Ok flow)
+    in
+
+    let send_notify recv_task (ip, data) =
       let connect_and_send ip =
-        connect ip >>= function
+        connect recv_task ip >>= function
         | Ok flow -> Dns.send_tcp flow data
         | Error () -> Lwt.return (Error ())
       in
@@ -44,7 +46,7 @@ module Make (P : Mirage_clock_lwt.PCLOCK) (M : Mirage_clock_lwt.MCLOCK) (TIME : 
          | Error () -> drop ip ; connect_and_send ip) >>= function
       | Ok () -> Lwt.return_unit
       | Error () ->
-        drop ip ; Dns.send_udp stack port ip dport data
+        drop ip ; Dns.send_udp stack port ip 53 data
     in
 
     let maybe_update_state t =
@@ -55,15 +57,46 @@ module Make (P : Mirage_clock_lwt.PCLOCK) (M : Mirage_clock_lwt.MCLOCK) (TIME : 
         Lwt.return_unit
       else
         on_update ~old:(trie old) t
-    and maybe_notify t now ts = function
+    and maybe_notify recv_task t now ts = function
       | None -> Lwt.return_unit
       | Some n -> on_notify n t >>= function
         | None -> Lwt.return_unit
         | Some trie ->
           let state', outs = Udns_server.Primary.with_data t now ts trie in
           state := state';
-          Lwt_list.iter_p send_notify outs
+          Lwt_list.iter_p (send_notify recv_task) outs
     in
+
+    let rec recv_task ip port flow () =
+      let f = Dns.of_flow flow in
+      tcp_out := Dns.IM.add ip flow !tcp_out ;
+      let rec loop () =
+        Dns.read_tcp f >>= function
+        | Error () -> drop ip ; Lwt.return_unit
+        | Ok data ->
+          let now = Ptime.v (P.now_d_ps ()) in
+          let elapsed = M.elapsed_ns () in
+          let t, answer, notify, n = Udns_server.Primary.handle_buf !state now elapsed `Tcp ip port data in
+          maybe_update_state t >>= fun () ->
+          maybe_notify recv_task t now elapsed n >>= fun () ->
+          Lwt_list.iter_p (send_notify recv_task) notify >>= fun () ->
+          match answer with
+          | None -> Log.warn (fun m -> m "empty answer") ; loop ()
+          | Some answer ->
+            Dns.send_tcp flow answer >>= function
+            | Ok () -> loop ()
+            | Error () -> drop ip ; Lwt.return_unit
+      in
+      loop ()
+    in
+
+    let tcp_cb flow =
+      let dst_ip, dst_port = T.dst flow in
+      Log.info (fun m -> m "tcp connection from %a:%d" Ipaddr.V4.pp dst_ip dst_port) ;
+      recv_task dst_ip dst_port flow ()
+    in
+    S.listen_tcpv4 stack ~port tcp_cb ;
+    Log.info (fun m -> m "DNS server listening on TCP port %d" port) ;
 
     let udp_cb ~src ~dst:_ ~src_port buf =
       Log.info (fun m -> m "udp frame from %a:%d" Ipaddr.V4.pp src src_port) ;
@@ -71,46 +104,20 @@ module Make (P : Mirage_clock_lwt.PCLOCK) (M : Mirage_clock_lwt.MCLOCK) (TIME : 
       let elapsed = M.elapsed_ns () in
       let t, answer, notify, n = Udns_server.Primary.handle_buf !state now elapsed `Udp src src_port buf in
       maybe_update_state t >>= fun () ->
-      maybe_notify t now elapsed n >>= fun () ->
+      maybe_notify recv_task t now elapsed n >>= fun () ->
       (match answer with
        | None -> Log.warn (fun m -> m "empty answer") ; Lwt.return_unit
        | Some answer -> Dns.send_udp stack port src src_port answer) >>= fun () ->
-      Lwt_list.iter_p send_notify notify
+      Lwt_list.iter_p (send_notify recv_task) notify
     in
     S.listen_udpv4 stack ~port udp_cb ;
     Log.info (fun m -> m "DNS server listening on UDP port %d" port) ;
-    let tcp_cb flow =
-      let dst_ip, dst_port = T.dst flow in
-      Log.info (fun m -> m "tcp connection from %a:%d" Ipaddr.V4.pp dst_ip dst_port) ;
-      let f = Dns.of_flow flow in
-      tcp_out := Dns.IM.add dst_ip flow !tcp_out ;
-      let rec loop () =
-        Dns.read_tcp f >>= function
-        | Error () -> drop dst_ip ; Lwt.return_unit
-        | Ok data ->
-          let now = Ptime.v (P.now_d_ps ()) in
-          let elapsed = M.elapsed_ns () in
-          let t, answer, notify, n = Udns_server.Primary.handle_buf !state now elapsed `Tcp dst_ip dst_port data in
-          maybe_update_state t >>= fun () ->
-          maybe_notify t now elapsed n >>= fun () ->
-          Lwt_list.iter_p send_notify notify >>= fun () ->
-          match answer with
-          | None -> Log.warn (fun m -> m "empty answer") ; loop ()
-          | Some answer ->
-            Dns.send_tcp flow answer >>= function
-            | Ok () -> loop ()
-            | Error () -> drop dst_ip ; Lwt.return_unit
-      in
-      loop ()
-    in
-    S.listen_tcpv4 stack ~port tcp_cb ;
-    Log.info (fun m -> m "DNS server listening on TCP port %d" port) ;
     let rec time () =
       let now = Ptime.v (P.now_d_ps ()) in
       let elapsed = M.elapsed_ns () in
       let t, notifies = Udns_server.Primary.timer !state now elapsed in
       maybe_update_state t >>= fun () ->
-      Lwt_list.iter_p send_notify notifies >>= fun () ->
+      Lwt_list.iter_p (send_notify recv_task) notifies >>= fun () ->
       TIME.sleep_ns (Duration.of_sec timer) >>= fun () ->
       time ()
     in

--- a/resolver/udns_resolver.ml
+++ b/resolver/udns_resolver.ml
@@ -215,7 +215,7 @@ let scrub_it mode t proto zone edns ts p =
 let handle_primary t now ts proto sender sport packet _request buf =
   (* makes only sense to ask primary for query=true since we'll never issue questions from primary *)
   let handle_inner name =
-    let t, answer, _, _ = Udns_server.Primary.handle_packet t ts proto sender sport packet name in
+    let t, answer, _, _ = Udns_server.Primary.handle_packet t now ts proto sender sport packet name in
     match answer with
     | None -> `None (* TODO incoming ??? are never replied to - should be revised!? *)
     | Some reply ->

--- a/server/udns_server.ml
+++ b/server/udns_server.ml
@@ -524,17 +524,10 @@ module Notification = struct
         out)
       ns (IPM.empty, [])
 
-  let notify conn ns server now ts zone soa =
-    let remotes = to_notify conn ~data:server.data ~auth:server.auth zone in
-    Log.debug (fun m -> m "notifying %a: %a" Domain_name.pp zone
-                  Fmt.(list ~sep:(unit ",@ ")
-                         (pair ~sep:(unit ", key ") Ipaddr.V4.pp
-                            (option ~none:(unit "none") Domain_name.pp)))
-                  (IPM.bindings remotes));
+  let notify_one ns server now ts zone soa ip key =
     let packet =
       let question = Packet.Question.create zone Soa
       and header =
-        (* TODO: all are getting the same ID *)
         let id = Randomconv.int ~bound:(1 lsl 16 - 1) server.rng in
         (id, authoritative)
       in
@@ -549,10 +542,20 @@ module Notification = struct
       let map' = Domain_name.Map.add zone data map in
       IPM.add ip map' ns
     in
+    let out, mac = encode_and_sign key server now packet in
+    let ns = add_to_ns ns ip key mac in
+    (ns, (ip, out))
+
+  let notify conn ns server now ts zone soa =
+    let remotes = to_notify conn ~data:server.data ~auth:server.auth zone in
+    Log.debug (fun m -> m "notifying %a: %a" Domain_name.pp zone
+                  Fmt.(list ~sep:(unit ",@ ")
+                         (pair ~sep:(unit ", key ") Ipaddr.V4.pp
+                            (option ~none:(unit "none") Domain_name.pp)))
+                  (IPM.bindings remotes));
     IPM.fold (fun ip key (ns, outs) ->
-        let out, mac = encode_and_sign key server now packet in
-        let ns = add_to_ns ns ip key mac in
-        ns, (ip, out) :: outs)
+        let ns, out = notify_one ns server now ts zone soa ip key in
+        ns, out :: outs)
       remotes (ns, [])
 
   let received_reply ns ip reply =
@@ -711,10 +714,28 @@ module Primary = struct
     match p.Packet.data with
     | `Query ->
       (* if there was a (transfer-key) signed SOA, and tcp, we add to notification list! *)
-      let l' = match tcp_soa_query proto p.question, key with
+      let l', ns', outs = match tcp_soa_query proto p.question, key with
         | Ok zone, Some key when Authentication.is_op `Transfer key ->
-          Notification.insert ~data:t.data ~auth:t.auth l ~zone ~key ip
-        | _ -> l
+          let zones, notify =
+            if Domain_name.(equal root zone) then
+              Udns_trie.fold Soa t.data (fun name soa (zs, n) ->
+                  Domain_name.Set.add name zs, (name, soa)::n)
+                (Domain_name.Set.empty, [])
+            else
+              Domain_name.Set.singleton zone, []
+          in
+          let l' = Domain_name.Set.fold (fun zone l ->
+              Notification.insert ~data:t.data ~auth:t.auth l ~zone ~key ip)
+              zones l
+          in
+          let ns, outs =
+            List.fold_left (fun (ns, outs) (name, soa) ->
+                let ns, out = Notification.notify_one ns t now ts name soa ip (Some key) in
+                ns, out :: outs)
+                (ns, []) notify
+          in
+          l', ns, outs
+        | _ -> l, ns, []
       in
       let answer =
         let flags, data, additional = match handle_question t p.question with
@@ -723,7 +744,7 @@ module Primary = struct
         in
         Packet.create ?additional (fst p.header, flags) p.question data
       in
-      (t, l', ns), Some answer, [], None
+      (t, l', ns'), Some answer, outs, None
     | `Update u ->
       let t', (flags, answer), stuff =
         match handle_update t proto key p.question u with

--- a/server/udns_server.ml
+++ b/server/udns_server.ml
@@ -528,8 +528,8 @@ module Notification = struct
     let remotes = to_notify conn ~data:server.data ~auth:server.auth zone in
     Log.debug (fun m -> m "notifying %a: %a" Domain_name.pp zone
                   Fmt.(list ~sep:(unit ",@ ")
-                         (pair ~sep:(unit ", key") Ipaddr.V4.pp
-                            (option ~none:(unit "no key") Domain_name.pp)))
+                         (pair ~sep:(unit ", key ") Ipaddr.V4.pp
+                            (option ~none:(unit "none") Domain_name.pp)))
                   (IPM.bindings remotes));
     let packet =
       let question = Packet.Question.create zone Soa
@@ -787,7 +787,10 @@ module Primary = struct
         t, answer, out, notify
       in
       let server, _, ns = t in
-      let mac = Notification.mac ns ip p in
+      let mac = match p.Packet.data with
+        | `Notify_ack | `Rcode_error _ -> Notification.mac ns ip p
+        | _ -> None
+      in
       match handle_tsig ?mac server now p buf with
       | Error (e, data) ->
         Log.err (fun m -> m "error %a while handling tsig" Tsig_op.pp_e e) ;

--- a/server/udns_server.ml
+++ b/server/udns_server.ml
@@ -746,7 +746,7 @@ module Primary = struct
     | `Axfr_reply data ->
       Logs.warn (fun m -> m "unsolicited AXFR reply %a, ignoring" Packet.Axfr.pp data);
       (t, l, ns), None, [], None
-    | `Notify_ack ->
+    | `Notify_ack | `Rcode_error (Rcode.NotAuth, Opcode.Notify, _) ->
       let ns' = Notification.received_reply ns ip p in
       (t, l, ns'), None, [], None
     | `Notify soa ->

--- a/server/udns_server.mli
+++ b/server/udns_server.mli
@@ -61,8 +61,8 @@ module Primary : sig
   val data : s -> Udns_trie.t
   (** [data s] is the data store of [s]. *)
 
-  val with_data : s -> int64 -> Udns_trie.t -> s * (Ipaddr.V4.t * Cstruct.t) list
-  (** [with_data s ts trie] replaces the current data with [trie] in [s].
+  val with_data : s -> Ptime.t -> int64 -> Udns_trie.t -> s * (Ipaddr.V4.t * Cstruct.t) list
+  (** [with_data s now ts trie] replaces the current data with [trie] in [s].
       The returned notifications should be send out. *)
 
   val create : ?keys:(Domain_name.t * Dnskey.t) list ->
@@ -70,10 +70,10 @@ module Primary : sig
     ?tsig_sign:Tsig_op.sign -> rng:(int -> Cstruct.t) -> Udns_trie.t -> s
   (** [create ~keys ~a ~tsig_verify ~tsig_sign ~rng data] creates a primary server. *)
 
-  val handle_packet : s -> int64 -> proto -> Ipaddr.V4.t -> int ->
+  val handle_packet : s -> Ptime.t -> int64 -> proto -> Ipaddr.V4.t -> int ->
     Packet.t -> Domain_name.t option ->
     s * Packet.t option * (Ipaddr.V4.t * Cstruct.t) list * [ `Notify of Soa.t option | `Signed_notify of Soa.t option ] option
-  (** [handle_packet s now src src_port proto key packet] handles the given
+  (** [handle_packet s now ts src src_port proto key packet] handles the given
      [packet], returning new state, an answer, and potentially notify packets to
      secondary name servers. *)
 
@@ -86,8 +86,8 @@ module Primary : sig
   val closed : s -> Ipaddr.V4.t -> s
   (** [closed s ip] marks the connection to [ip] closed. *)
 
-  val timer : s -> int64 -> s * (Ipaddr.V4.t * Cstruct.t) list
-  (** [timer s now] may encode some notify if they were not acknowledget by the
+  val timer : s -> Ptime.t -> int64 -> s * (Ipaddr.V4.t * Cstruct.t) list
+  (** [timer s now ts] may encode some notify if they were not acknowledget by the
      other side. *)
 
 end

--- a/src/udns.ml
+++ b/src/udns.ml
@@ -1172,7 +1172,7 @@ module Tsig = struct
     let fudge = Ptime.Span.of_int_s fudge in
     { algorithm ; signed ; fudge ; mac ; original_id ; error ; other },
     names,
-    off + 16 + mac_len + other_len
+    off' + 16 + mac_len + other_len
 
   let encode_48bit_time buf ?(off = 0) ts =
     match ptime_span_to_int64 (Ptime.to_span ts) with


### PR DESCRIPTION
esp last commit is of interest, will clean up other commits. I'm sure there's more ``[ `host ] Domain_name.t`` to be introduced (i.e. all zone boundaries should be on hostnames, ...) -- but it's also a bit unclear where to require hostnames, and where domain names are sufficient (i.e. zone parser -- should origin be a hostname? can we verify that each zone we add to dns_trie is a hostname?).

in respect to regression2/3 -- I'm not sure whether SOA nameserver (/MX) should really be hostname -- from what our server should accept, this is very reasonable, for what `odig` should accept & print, I think this is a bit too limited.